### PR TITLE
fix detect-end-of-line

### DIFF
--- a/src/inquisitor.lisp
+++ b/src/inquisitor.lisp
@@ -76,7 +76,7 @@
             (with-byte-array (vec 500)
               (prog1
                   (loop for n = (read-sequence vec stream)
-                     with eol = (eol-guess-from-vector vec)
+                     for eol = (eol-guess-from-vector vec)
                      until (or (zerop n)
                                (not (null eol)))
                      finally (return eol))


### PR DESCRIPTION
detect-end-of-lineのloopマクロが間違えてて空のバッファを走査してnilを返すバグがありました
