### PR TITLE
R.I.P. `*detecting-buffer-size*`

### DIFF
--- a/inquisitor-test.asd
+++ b/inquisitor-test.asd
@@ -17,12 +17,11 @@
   :components ((:module "t"
                 :components
                 ((:file "names")
-                 (:file "test-util")
-                 (:test-file "util" :depends-on ("test-util"))
-                 (:test-file "eol" :depends-on ("test-util"))
-                 (:test-file "encoding" :depends-on ("test-util"))
+                 (:test-file "util")
+                 (:test-file "eol")
+                 (:test-file "encoding")
                  (:test-file "external-format")
-                 (:test-file "inquisitor" :depends-on ("test-util")))))
+                 (:test-file "inquisitor"))))
 
   :defsystem-depends-on (:prove-asdf)
   :perform (test-op :after (op c)

--- a/inquisitor-test.asd
+++ b/inquisitor-test.asd
@@ -13,7 +13,6 @@
   :license "MIT"
   :depends-on (:inquisitor
                :babel
-               :drakma
                :prove)
   :components ((:module "t"
                 :components

--- a/src/encoding/dfa.lisp
+++ b/src/encoding/dfa.lisp
@@ -74,56 +74,56 @@
 
   (defun resolve-states (state-defs)
     (let ((states (mapcar (lambda (d i)
-			                (make-instance '<state> :name (car d) :index i))
-			              state-defs
-			              (loop for i from 0 below (length state-defs) collect i))))
+                            (make-instance '<state> :name (car d) :index i))
+                          state-defs
+                          (loop for i from 0 below (length state-defs) collect i))))
       (labels ((gen (s d i &aux (num-arcs (length (cdr d))))
-		         (setf (arcs-of s)
-		               (mapcar (lambda (arc aindex)
-				                 (make-instance '<arc>
-						                        :from-state s
-						                        :to-state (or (find-if (lambda (e)
-									                                     (eq (name-of e) (cadr arc)))
-								                                       states)
-							                                  (error (format nil "no such state ~A" (cadr arc))))
-						                        :ranges (car arc)
-						                        :index aindex
-						                        :score (caddr arc)))
-			                   (cdr d)
-			                   (loop repeat num-arcs for x from i collect x)))
-		         (+ i num-arcs))
-	           (fold (fun  state arg1 arg2)
-		         (if (or (null arg1) (null arg2))
-		             state
-		             (fold fun
-			               (funcall fun (car arg1) (car arg2) state)
-			               (cdr arg1)
-			               (cdr arg2)))))
-	    (fold #'gen 0 states state-defs)
-	    states)))
+                 (setf (arcs-of s)
+                       (mapcar (lambda (arc aindex)
+                                 (make-instance '<arc>
+                                                :from-state s
+                                                :to-state (or (find-if (lambda (e)
+                                                                         (eq (name-of e) (cadr arc)))
+                                                                       states)
+                                                              (error (format nil "no such state ~A" (cadr arc))))
+                                                :ranges (car arc)
+                                                :index aindex
+                                                :score (caddr arc)))
+                               (cdr d)
+                               (loop repeat num-arcs for x from i collect x)))
+                 (+ i num-arcs))
+               (fold (fun  state arg1 arg2)
+                 (if (or (null arg1) (null arg2))
+                     state
+                     (fold fun
+                           (funcall fun (car arg1) (car arg2) state)
+                           (cdr arg1)
+                           (cdr arg2)))))
+        (fold #'gen 0 states state-defs)
+        states)))
 
 ;;;;;; DFA
 
   (defmacro define-dfa (name &body states)
     (let ((name-st (intern (string-upcase (format nil "+~A-ST+" name))))
-	      (name-ar (intern (string-upcase (format nil "+~A-AR+" name)))))
+          (name-ar (intern (string-upcase (format nil "+~A-AR+" name)))))
       `(unless (boundp ',name-st)
-	     (let ((dfa (make-instance '<dfa> :name ',name :states (resolve-states ',states))))
-	       (defconstant ,name-st (apply #'vector
-					                    (loop for state in (states-of dfa)
-					                       collect (let ((vec (make-array 256 :initial-element -1)))
-							                         (flet ((b2i (byte) (if (characterp byte) (char-code byte) byte)))
-							                           (dolist (br (arcs-of state))
-							                             (dolist (range (ranges-of br))
-							                               (if (consp range)
-								                               (fill vec (index-of br)
-									                                 :start (b2i (car range))
-									                                 :end   (+ (b2i (cadr range)) 1))
-								                               (setf (aref vec (b2i range)) (index-of br)))))
-							                           vec)))))
-	       (defconstant ,name-ar (apply #'vector
-					                    (loop for arc in (loop for state in (states-of dfa) appending (arcs-of state))
-					                       collect (cons (index-of (to-state-of arc)) (score-of arc)))))))))
+         (let ((dfa (make-instance '<dfa> :name ',name :states (resolve-states ',states))))
+           (defconstant ,name-st (apply #'vector
+                                        (loop for state in (states-of dfa)
+                                           collect (let ((vec (make-array 256 :initial-element -1)))
+                                                     (flet ((b2i (byte) (if (characterp byte) (char-code byte) byte)))
+                                                       (dolist (br (arcs-of state))
+                                                         (dolist (range (ranges-of br))
+                                                           (if (consp range)
+                                                               (fill vec (index-of br)
+                                                                     :start (b2i (car range))
+                                                                     :end   (+ (b2i (cadr range)) 1))
+                                                               (setf (aref vec (b2i range)) (index-of br)))))
+                                                       vec)))))
+           (defconstant ,name-ar (apply #'vector
+                                        (loop for arc in (loop for state in (states-of dfa) appending (arcs-of state))
+                                           collect (cons (index-of (to-state-of arc)) (score-of arc)))))))))
   ) ;; eval-when
 
 
@@ -144,57 +144,57 @@
 (defmacro dfa-next (dfa ch)
   `(when (dfa-alive ,dfa)
      (let ((temp (svref
-		          (svref (states ,dfa) (state ,dfa))
-		          ,ch)))
+                  (svref (states ,dfa) (state ,dfa))
+                  ,ch)))
        (if (< (the fixnum temp) (the fixnum  0))
-	       (setf (state ,dfa) -1)
-	       (setf (state ,dfa) (the fixnum (car (svref (arcs ,dfa) temp)))
-		         (score ,dfa) (* (the double-float (score ,dfa))
-				                 (the single-float (cdr (svref (arcs ,dfa) temp)))))))))
+           (setf (state ,dfa) -1)
+           (setf (state ,dfa) (the fixnum (car (svref (arcs ,dfa) temp)))
+                 (score ,dfa) (* (the double-float (score ,dfa))
+                                 (the single-float (cdr (svref (arcs ,dfa) temp)))))))))
 
 (defmacro dfa-process (order ch)
   (with-gensyms (gorder gch)
     `(let ((,gorder ,order)
-	       (,gch ,ch))
-	   (or (loop for dfa in ,gorder
-		      for i of-type fixnum from 0
-		  do 
-		     (when (dfa-alive dfa)
-		       (when (dfa-alone dfa ,gorder)
-			 (return (dfa-name dfa)))
-		       (dfa-next (nth i ,gorder) ,gch)))
-	    nil))))
+           (,gch ,ch))
+       (or (loop for dfa in ,gorder
+              for i of-type fixnum from 0
+              do 
+                (when (dfa-alive dfa)
+                  (when (dfa-alone dfa ,gorder)
+                    (return (dfa-name dfa)))
+                  (dfa-next (nth i ,gorder) ,gch)))
+           nil))))
 
 (defun dfa-alone (dfa order)
   (unless (dfa-alive dfa)
     (return-from dfa-alone nil))
   (loop for d in order
-	 do (if (and (not (eql dfa d)) (dfa-alive d))
-	        (return-from dfa-alone nil)))
+     do (if (and (not (eql dfa d)) (dfa-alive d))
+            (return-from dfa-alone nil)))
   t)
 
 (defun dfa-top (order)
   (let ((top nil))
     (loop for dfa in order do
          (if (and (dfa-alive dfa)
-	              (or (null top)
-		              (> (the double-float (score dfa)) (the double-float (score top)))))
-	         (setf top dfa)))
+                  (or (null top)
+                      (> (the double-float (score dfa)) (the double-float (score top)))))
+             (setf top dfa)))
     top))
 
 (defun dfa-none (order)
   (dolist (d order)
     (if (dfa-alive d)
-	    (return-from dfa-none nil)))
+        (return-from dfa-none nil)))
   t)
 
 (defmacro generate-order (&rest encodings)
   `(list
     ,@(mapcar (lambda (enc)
-		        (let ((dfa-st (find-symbol (string-upcase (format nil "+~A-ST+" (symbol-name enc)))
+                (let ((dfa-st (find-symbol (string-upcase (format nil "+~A-ST+" (symbol-name enc)))
                                            :inquisitor.encoding.table))
-		              (dfa-ar (find-symbol (string-upcase (format nil "+~A-AR+" (symbol-name enc)))
+                      (dfa-ar (find-symbol (string-upcase (format nil "+~A-AR+" (symbol-name enc)))
                                            :inquisitor.encoding.table))
-		              (dfa-name enc))
-		          `(dfa-init ,dfa-st ,dfa-ar ,dfa-name)))
-		      encodings)))
+                      (dfa-name enc))
+                  `(dfa-init ,dfa-st ,dfa-ar ,dfa-name)))
+              encodings)))

--- a/src/encoding/dfa.lisp
+++ b/src/encoding/dfa.lisp
@@ -53,8 +53,6 @@
            :generate-order))
 (in-package :inquisitor.encoding.dfa)
 
-
-
 (eval-when (:compile-toplevel :load-toplevel :execute)
 
   (defclass <dfa> ()
@@ -76,56 +74,56 @@
 
   (defun resolve-states (state-defs)
     (let ((states (mapcar (lambda (d i)
-			    (make-instance '<state> :name (car d) :index i))
-			  state-defs
-			  (loop for i from 0 below (length state-defs) collect i))))
+			                (make-instance '<state> :name (car d) :index i))
+			              state-defs
+			              (loop for i from 0 below (length state-defs) collect i))))
       (labels ((gen (s d i &aux (num-arcs (length (cdr d))))
-		 (setf (arcs-of s)
-		       (mapcar (lambda (arc aindex)
-				 (make-instance '<arc>
-						:from-state s
-						:to-state (or (find-if (lambda (e)
-									 (eq (name-of e) (cadr arc)))
-								       states)
-							      (error (format nil "no such state ~A" (cadr arc))))
-						:ranges (car arc)
-						:index aindex
-						:score (caddr arc)))
-			       (cdr d)
-			       (loop repeat num-arcs for x from i collect x)))
-		 (+ i num-arcs))
-	       (fold (fun  state arg1 arg2)
-		 (if (or (null arg1) (null arg2))
-		     state
-		     (fold fun
-			   (funcall fun (car arg1) (car arg2) state)
-			   (cdr arg1)
-			   (cdr arg2)))))
-	(fold #'gen 0 states state-defs)
-	states)))
+		         (setf (arcs-of s)
+		               (mapcar (lambda (arc aindex)
+				                 (make-instance '<arc>
+						                        :from-state s
+						                        :to-state (or (find-if (lambda (e)
+									                                     (eq (name-of e) (cadr arc)))
+								                                       states)
+							                                  (error (format nil "no such state ~A" (cadr arc))))
+						                        :ranges (car arc)
+						                        :index aindex
+						                        :score (caddr arc)))
+			                   (cdr d)
+			                   (loop repeat num-arcs for x from i collect x)))
+		         (+ i num-arcs))
+	           (fold (fun  state arg1 arg2)
+		         (if (or (null arg1) (null arg2))
+		             state
+		             (fold fun
+			               (funcall fun (car arg1) (car arg2) state)
+			               (cdr arg1)
+			               (cdr arg2)))))
+	    (fold #'gen 0 states state-defs)
+	    states)))
 
 ;;;;;; DFA
 
   (defmacro define-dfa (name &body states)
     (let ((name-st (intern (string-upcase (format nil "+~A-ST+" name))))
-	  (name-ar (intern (string-upcase (format nil "+~A-AR+" name)))))
+	      (name-ar (intern (string-upcase (format nil "+~A-AR+" name)))))
       `(unless (boundp ',name-st)
-	 (let ((dfa (make-instance '<dfa> :name ',name :states (resolve-states ',states))))
-	   (defconstant ,name-st (apply #'vector
-					(loop for state in (states-of dfa)
-					      collect (let ((vec (make-array 256 :initial-element -1)))
-							(flet ((b2i (byte) (if (characterp byte) (char-code byte) byte)))
-							  (dolist (br (arcs-of state))
-							    (dolist (range (ranges-of br))
-							      (if (consp range)
-								  (fill vec (index-of br)
-									:start (b2i (car range))
-									:end   (+ (b2i (cadr range)) 1))
-								  (setf (aref vec (b2i range)) (index-of br)))))
-							  vec)))))
-	   (defconstant ,name-ar (apply #'vector
-					(loop for arc in (loop for state in (states-of dfa) appending (arcs-of state))
-					      collect (cons (index-of (to-state-of arc)) (score-of arc)))))))))
+	     (let ((dfa (make-instance '<dfa> :name ',name :states (resolve-states ',states))))
+	       (defconstant ,name-st (apply #'vector
+					                    (loop for state in (states-of dfa)
+					                       collect (let ((vec (make-array 256 :initial-element -1)))
+							                         (flet ((b2i (byte) (if (characterp byte) (char-code byte) byte)))
+							                           (dolist (br (arcs-of state))
+							                             (dolist (range (ranges-of br))
+							                               (if (consp range)
+								                               (fill vec (index-of br)
+									                                 :start (b2i (car range))
+									                                 :end   (+ (b2i (cadr range)) 1))
+								                               (setf (aref vec (b2i range)) (index-of br)))))
+							                           vec)))))
+	       (defconstant ,name-ar (apply #'vector
+					                    (loop for arc in (loop for state in (states-of dfa) appending (arcs-of state))
+					                       collect (cons (index-of (to-state-of arc)) (score-of arc)))))))))
   ) ;; eval-when
 
 
@@ -146,20 +144,20 @@
 (defmacro dfa-next (dfa ch)
   `(when (dfa-alive ,dfa)
      (let ((temp (svref
-		  (svref (states ,dfa) (state ,dfa))
-		  ,ch)))
+		          (svref (states ,dfa) (state ,dfa))
+		          ,ch)))
        (if (< (the fixnum temp) (the fixnum  0))
-	   (setf (state ,dfa) -1)
-	   (setf (state ,dfa) (the fixnum (car (svref (arcs ,dfa) temp)))
-		 (score ,dfa) (* (the double-float (score ,dfa))
-				 (the single-float (cdr (svref (arcs ,dfa) temp)))))))))
+	       (setf (state ,dfa) -1)
+	       (setf (state ,dfa) (the fixnum (car (svref (arcs ,dfa) temp)))
+		         (score ,dfa) (* (the double-float (score ,dfa))
+				                 (the single-float (cdr (svref (arcs ,dfa) temp)))))))))
 
 (defmacro dfa-process (order ch)
   (with-gensyms (gorder gch)
-     `(let ((,gorder ,order)
-	   (,gch ,ch))
-	(or (loop for dfa in ,gorder
-		  for i of-type fixnum from 0
+    `(let ((,gorder ,order)
+	       (,gch ,ch))
+	   (or (loop for dfa in ,gorder
+		      for i of-type fixnum from 0
 		  do 
 		     (when (dfa-alive dfa)
 		       (when (dfa-alone dfa ,gorder)
@@ -171,32 +169,32 @@
   (unless (dfa-alive dfa)
     (return-from dfa-alone nil))
   (loop for d in order
-	do (if (and (not (eql dfa d)) (dfa-alive d))
-	       (return-from dfa-alone nil)))
+	 do (if (and (not (eql dfa d)) (dfa-alive d))
+	        (return-from dfa-alone nil)))
   t)
 
 (defun dfa-top (order)
   (let ((top nil))
     (loop for dfa in order do
-      (if (and (dfa-alive dfa)
-	       (or (null top)
-		   (> (the double-float (score dfa)) (the double-float (score top)))))
-	  (setf top dfa)))
+         (if (and (dfa-alive dfa)
+	              (or (null top)
+		              (> (the double-float (score dfa)) (the double-float (score top)))))
+	         (setf top dfa)))
     top))
 
 (defun dfa-none (order)
   (dolist (d order)
     (if (dfa-alive d)
-	(return-from dfa-none nil)))
+	    (return-from dfa-none nil)))
   t)
 
 (defmacro generate-order (&rest encodings)
   `(list
     ,@(mapcar (lambda (enc)
-		(let ((dfa-st (find-symbol (string-upcase (format nil "+~A-ST+" (symbol-name enc)))
-                                   :inquisitor.encoding.table))
-		      (dfa-ar (find-symbol (string-upcase (format nil "+~A-AR+" (symbol-name enc)))
-                                   :inquisitor.encoding.table))
-		      (dfa-name enc))
-		  `(dfa-init ,dfa-st ,dfa-ar ,dfa-name)))
-		  encodings)))
+		        (let ((dfa-st (find-symbol (string-upcase (format nil "+~A-ST+" (symbol-name enc)))
+                                           :inquisitor.encoding.table))
+		              (dfa-ar (find-symbol (string-upcase (format nil "+~A-AR+" (symbol-name enc)))
+                                           :inquisitor.encoding.table))
+		              (dfa-name enc))
+		          `(dfa-init ,dfa-st ,dfa-ar ,dfa-name)))
+		      encodings)))

--- a/src/encoding/guess.lisp
+++ b/src/encoding/guess.lisp
@@ -112,10 +112,10 @@
          ;; special treatment of iso-2022 escape sequence
            (when (and (= (the fixnum c) (the fixnum #x1b))
                       (< (the fixnum i) (the fixnum (1- len))))
-             (setf c (aref buffer (the fixnum (incf i))))
-             (when (or (= (the fixnum c) (the fixnum #x24))  ; $
-                       (= (the fixnum c) (the fixnum #x28))) ; (
-               (return-from guess-body :iso-2022-jp)))
+             (let ((c (aref buffer (the fixnum (1+ i)))))
+               (when (or (= (the fixnum c) (the fixnum #x24))  ; $
+                         (= (the fixnum c) (the fixnum #x28))) ; (
+                 (return-from guess-body :iso-2022-jp))))
 
            (awhen (dfa-process order c)
              (return-from guess-body it))
@@ -145,10 +145,10 @@
          ;; special treatment of iso-2022 escape sequence
            (when (and (= (the fixnum c) (the fixnum #x1b))
                       (< (the fixnum i) (the fixnum (1- len))))
-             (setf c (aref buffer (the fixnum (incf i))))
-             (when (or (= (the fixnum c) (the fixnum #x24))  ; $
-                       (= (the fixnum c) (the fixnum #x28))) ; (
-               (return-from guess-body :iso-2022-tw)))
+             (let ((c (aref buffer (the fixnum (1+ i)))))
+               (when (or (= (the fixnum c) (the fixnum #x24))  ; $
+                         (= (the fixnum c) (the fixnum #x28))) ; (
+                 (return-from guess-body :iso-2022-tw))))
 
            (awhen (dfa-process order c)
              (return-from guess-body it))

--- a/src/encoding/guess.lisp
+++ b/src/encoding/guess.lisp
@@ -132,7 +132,8 @@ independent_ name, `order` is a state at this function stops guessing process."
                                ,order
                                (generate-order ,@encs))))
            ;; special treatment of BOM
-           (check-byte-order-mark ,buffer :ucs-2be :ucs-2le ,order-var)
+           (unless ,order-var
+             (check-byte-order-mark ,buffer :ucs-2be :ucs-2le ,order-var))
 
            (do-guess-loop ,vars ,buffer
              ,@specialized-check

--- a/src/encoding/guess.lisp
+++ b/src/encoding/guess.lisp
@@ -56,18 +56,17 @@
            :ces-guess-from-vector))
 (in-package :inquisitor.encoding.guess)
 
-
 (defparameter +schemes+
-  '((:jp guess-jp) ;; japanese
-    (:tw guess-tw) ;; taiwanese
-    (:cn guess-cn) ;; chinese
-    (:kr guess-kr) ;; korean
-    (:ru guess-ru) ;; russian
-    (:ar guess-ar) ;; arabic
-    (:tr guess-tr) ;; turkish
-    (:gr guess-gr) ;; greek
-    (:hw guess-hw) ;; hebrew
-    (:pl guess-pl) ;; polish
+  '((:jp guess-jp)   ;; japanese
+    (:tw guess-tw)   ;; taiwanese
+    (:cn guess-cn)   ;; chinese
+    (:kr guess-kr)   ;; korean
+    (:ru guess-ru)   ;; russian
+    (:ar guess-ar)   ;; arabic
+    (:tr guess-tr)   ;; turkish
+    (:gr guess-gr)   ;; greek
+    (:hw guess-hw)   ;; hebrew
+    (:pl guess-pl)   ;; polish
     (:bl guess-bl))) ;; baltic
 
 (defun list-available-scheme ()
@@ -124,15 +123,15 @@
              (return-from guess-body nil)))
 
       (aif (dfa-top order)
-	  (dfa-name it)
-	  nil))))
+           (dfa-name it)
+           nil))))
 
 
 (defun guess-tw (buffer)
   (block guess-body
     (let ((order (generate-order :utf-8 :big5))
           (len (length buffer))
-	  (c nil))
+          (c nil))
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
@@ -157,8 +156,8 @@
              (return-from guess-body nil)))
 
       (aif (dfa-top order)
-	  (dfa-name it)
-	  nil))))
+           (dfa-name it)
+           nil))))
 
 
 (defun guess-cn (buffer)
@@ -224,8 +223,8 @@
              (return-from guess-body nil)))
 
       (aif (dfa-top order)
-	  (dfa-name it)
-	  nil))))
+           (dfa-name it)
+           nil))))
 
 (defun guess-ar (buffer)
   (block guess-body
@@ -246,8 +245,8 @@
              (return-from guess-body nil)))
 
       (aif (dfa-top order)
-	  (dfa-name it)
-	  nil))))
+           (dfa-name it)
+           nil))))
 
 (defun guess-gr (buffer)
   (block guess-body
@@ -268,8 +267,8 @@
              (return-from guess-body nil)))
 
       (aif (dfa-top order)
-	  (dfa-name it)
-	  nil))))
+           (dfa-name it)
+           nil))))
 
 (defun guess-ru (buffer)
   (block guess-body
@@ -291,8 +290,8 @@
              (return-from guess-body nil)))
 
       (aif (dfa-top order)
-	  (dfa-name it)
-	  nil))))
+           (dfa-name it)
+           nil))))
 
 (defun guess-hw (buffer)
   (block guess-body
@@ -313,8 +312,8 @@
              (return-from guess-body nil)))
 
       (aif (dfa-top order)
-	  (dfa-name it)
-	  nil))))
+           (dfa-name it)
+           nil))))
 
 (defun guess-pl (buffer)
   (block guess-body
@@ -336,8 +335,8 @@
              (return-from guess-body nil)))
 
       (aif (dfa-top order)
-	  (dfa-name it)
-	  nil))))
+           (dfa-name it)
+           nil))))
 
 
 (defun guess-tr (buffer)
@@ -359,8 +358,8 @@
              (return-from guess-body nil)))
 
       (aif (dfa-top order)
-	  (dfa-name it)
-	  nil))))
+           (dfa-name it)
+           nil))))
 
 
 (defun guess-bl (buffer)
@@ -382,5 +381,5 @@
              (return-from guess-body nil)))
 
       (aif (dfa-top order)
-	  (dfa-name it)
-	  nil))))
+           (dfa-name it)
+           nil))))

--- a/src/encoding/guess.lisp
+++ b/src/encoding/guess.lisp
@@ -106,6 +106,16 @@
                   (setf ,last-var (aref ,buffer (the fixnum ,idx)))
                   (incf (the fixnum ,idx)))))))))
 
+(defmacro check-byte-order-mark (buffer big-endian-value little-endian-value order)
+  (once-only (buffer order)
+    `(when (>= (the fixnum (length ,buffer)) (the fixnum 2))
+       (cond ((and (= (aref ,buffer (the fixnum 0)) (the fixnum #xfe))
+                   (= (aref ,buffer (the fixnum 1)) (the fixnum #xff)))
+              (return-from guess-body (values ,big-endian-value ,order)))
+             ((and (= (aref ,buffer (the fixnum 0)) (the fixnum #xff))
+                   (= (aref ,buffer (the fixnum 1)) (the fixnum #xfe)))
+              (return-from guess-body (values ,little-endian-value ,order)))
+             (t nil)))))
 
 
 (defun guess-jp (buffer &optional order)
@@ -125,9 +135,7 @@
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
-      (case (%check-byte-order-mark buffer (length buffer))
-        (:big-endian (return-from guess-body (values :ucs-2be nil)))
-        (:little-endian (return-from guess-body (values :ucs-2le nil))))
+      (check-byte-order-mark buffer :ucs-2be :ucs-2le order)
 
       (do-guess-loop (c1 c2) buffer
         ;; special treatment of iso-2022 escape sequence
@@ -151,9 +159,7 @@
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
-      (case (%check-byte-order-mark buffer len)
-        (:big-endian (return-from guess-body :ucs-2be))
-        (:little-endian (return-from guess-body :ucs-2le)))
+      (check-byte-order-mark buffer :ucs-2be :ucs-2le order)
 
       (do-guess-loop (c1 c2) buffer
         ;; special treatment of iso-2022 escape sequence
@@ -177,9 +183,7 @@
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
-      (case (%check-byte-order-mark buffer len)
-        (:big-endian (return-from guess-body :ucs-2be))
-        (:little-endian (return-from guess-body :ucs-2le)))
+      (check-byte-order-mark buffer :ucs-2be :ucs-2le order)
 
       (do-guess-loop (c1 c2 c3) buffer
         ;; special treatment of iso-2022 escape sequence
@@ -204,9 +208,7 @@
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
-      (case (%check-byte-order-mark buffer len)
-        (:big-endian (return-from guess-body :ucs-2be))
-        (:little-endian (return-from guess-body :ucs-2le)))
+      (check-byte-order-mark buffer :ucs-2be :ucs-2le order)
 
       (Do-guess-loop (c1 c2 c3) buffer
         ;; special treatment of iso-2022 escape sequence
@@ -230,9 +232,7 @@
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
-      (case (%check-byte-order-mark buffer len)
-        (:big-endian (return-from guess-body :ucs-2be))
-        (:little-endian (return-from guess-body :ucs-2le)))
+      (check-byte-order-mark buffer :ucs-2be :ucs-2le order)
 
       (do-guess-loop (c1) buffer
         (awhen (dfa-process order c1)
@@ -250,9 +250,7 @@
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
-      (case (%check-byte-order-mark buffer len)
-        (:big-endian (return-from guess-body :ucs-2be))
-        (:little-endian (return-from guess-body :ucs-2le)))
+      (check-byte-order-mark buffer :ucs-2be :ucs-2le order)
 
       (do-guess-loop (c1) buffer
         (awhen (dfa-process order c1)
@@ -271,9 +269,7 @@
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
-      (case (%check-byte-order-mark buffer len)
-        (:big-endian (return-from guess-body :ucs-2be))
-        (:little-endian (return-from guess-body :ucs-2le)))
+      (check-byte-order-mark buffer :ucs-2be :ucs-2le order)
 
       (do-guess-loop (c1) buffer
            (awhen (dfa-process order c1)
@@ -291,9 +287,7 @@
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
-      (case (%check-byte-order-mark buffer len)
-        (:big-endian (return-from guess-body :ucs-2be))
-        (:little-endian (return-from guess-body :ucs-2le)))
+      (check-byte-order-mark buffer :ucs-2be :ucs-2le order)
 
       (do-guess-loop (c1) buffer
         (awhen (dfa-process order c1)
@@ -311,9 +305,7 @@
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
-      (case (%check-byte-order-mark buffer len)
-        (:big-endian (return-from guess-body :ucs-2be))
-        (:little-endian (return-from guess-body :ucs-2le)))
+      (check-byte-order-mark buffer :ucs-2be :ucs-2le order)
 
       (do-guess-loop (c1) buffer
         (awhen (dfa-process order c1)
@@ -332,9 +324,7 @@
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
-      (case (%check-byte-order-mark buffer len)
-        (:big-endian (return-from guess-body :ucs-2be))
-        (:little-endian (return-from guess-body :ucs-2le)))
+      (check-byte-order-mark buffer :ucs-2be :ucs-2le order)
 
       (do-guess-loop (c1) buffer
         (awhen (dfa-process order c1)
@@ -353,9 +343,7 @@
       (declare (dynamic-extent order))
 
       ;; special treatment of BOM
-      (case (%check-byte-order-mark buffer len)
-        (:big-endian (return-from guess-body :ucs-2be))
-        (:little-endian (return-from guess-body :ucs-2le)))
+      (check-byte-order-mark buffer :ucs-2be :ucs-2le order)
 
       (do-guess-loop (c1) buffer
         (awhen (dfa-process order c1)

--- a/src/encoding/guess.lisp
+++ b/src/encoding/guess.lisp
@@ -124,8 +124,6 @@
          (let ((,order-var (if ,order
                                ,order
                                (generate-order ,@encs))))
-           (declare (dynamic-extent order))
-
            ;; special treatment of BOM
            (check-byte-order-mark ,buffer :ucs-2be :ucs-2le ,order-var)
 

--- a/src/encoding/guess.lisp
+++ b/src/encoding/guess.lisp
@@ -76,6 +76,13 @@
   (mapcar #'car +schemes+))
 
 (defun ces-guess-from-vector (vector scheme &optional order)
+  "Guess character encoding scheme under the language `scheme`. `order` is a list
+of _states_: _states_ is list consist of a) dfa state at the point and b) score.
+Specifying `order` means, we can restart guessing from the point of `order`.
+
+`ces-guess-from-vector` returns `encoding` and `order`: `encoding` is an _implementation
+independent_ name, `order` is a state at this function stops guessing process."
+
   (macrolet ((guess (fn-name) `(funcall ,fn-name vector order)))
     (let ((fn-name (cadr (find scheme +schemes+ :key #'car))))
       (if fn-name
@@ -140,11 +147,6 @@
 
 
 (defun guess-jp (buffer &optional order)
-  "guess character encoding scheme in Japanese. `order` is a list of _states_:
-  _states_ is a pair (list) of a) dfa state at the point and b) score. Specifying
-  `order` means, we can restart guessing from the point of `order`
-
-  guess-jp returns `order` when stops guessing process as second value."
   (guess (buffer order (c1 c2) (:utf-8 :cp932 :euc-jp))
     ;; special treatment of iso-2022 escape sequence
     (when (and (= (the fixnum c1) (the fixnum #x1b))

--- a/src/encoding/guess.lisp
+++ b/src/encoding/guess.lisp
@@ -86,7 +86,7 @@ and `state`.
 `ces-guess-from-vector` returns `encoding` and `order`: `encoding` is an _implementation
 independent_ name, `order` is a state at this function stops guessing process."
 
-  (macrolet ((guess (fn-name) `(funcall ,fn-name vector order)))
+  (macrolet ((guess (fn-name) `(funcall ,fn-name vector order state)))
     (let ((fn-name (cadr (find scheme +schemes+ :key #'car))))
       (if fn-name
           (guess fn-name)

--- a/src/encoding/guess.lisp
+++ b/src/encoding/guess.lisp
@@ -75,8 +75,8 @@
 (defun list-available-scheme ()
   (mapcar #'car +schemes+))
 
-(defun ces-guess-from-vector (vector scheme)
-  (macrolet ((guess (fn-name) `(funcall ,fn-name vector)))
+(defun ces-guess-from-vector (vector scheme &optional order)
+  (macrolet ((guess (fn-name) `(funcall ,fn-name vector order)))
     (let ((fn-name (cadr (find scheme +schemes+ :key #'car))))
       (if fn-name
           (guess fn-name)

--- a/src/encoding/guess.lisp
+++ b/src/encoding/guess.lisp
@@ -273,7 +273,7 @@
 (defun guess-ru (buffer)
   (block guess-body
     (let ((order (generate-order :utf-8 :cp1251 :koi8-u :koi8-r :cp866
-			     :iso-8859-2 :iso-8859-5))
+                                 :iso-8859-2 :iso-8859-5))
           (len (length buffer)))
       (declare (dynamic-extent order))
 

--- a/src/encoding/guess.lisp
+++ b/src/encoding/guess.lisp
@@ -75,10 +75,13 @@
 (defun list-available-scheme ()
   (mapcar #'car +schemes+))
 
-(defun ces-guess-from-vector (vector scheme &optional order)
-  "Guess character encoding scheme under the language `scheme`. `order` is a list
-of _states_: _states_ is list consist of a) dfa state at the point and b) score.
-Specifying `order` means, we can restart guessing from the point of `order`.
+(defun ces-guess-from-vector (vector scheme &optional order state)
+  "Guess character encoding scheme under the language `scheme`. `order` is a _dfa state_:
+_dfa state_ is a list consist of a) nodes of dfa, b) arrows of dfa c) score and d) name.
+`state` is a state except dfa state. `state` may be used or not be used by each guess-*
+function of scheme, although you must be pass to this function.
+Specifying `order` and `state` means, we can restart guessing from the point of `order`
+and `state`.
 
 `ces-guess-from-vector` returns `encoding` and `order`: `encoding` is an _implementation
 independent_ name, `order` is a state at this function stops guessing process."

--- a/src/inquisitor.lisp
+++ b/src/inquisitor.lisp
@@ -55,18 +55,18 @@ method modifies `stream`'s file position."
   (if (byte-input-stream-p stream)
       (let* ((buffer-length *default-buffer-size*)
              (buffer (make-array buffer-length :element-type '(unsigned-byte 8)))
-             (order)
+             (ces-state)
              (encoding))
         (loop
            :for num-read := (read-sequence buffer stream)
            :if (< num-read buffer-length)
            :do (return-from detect-encoding
-                 (ces-guess-from-vector (subseq buffer 0 num-read) scheme order))
+                 (ces-guess-from-vector (subseq buffer 0 num-read) scheme ces-state))
            :else
-           :do (multiple-value-bind (enc ord)
-                   (ces-guess-from-vector (subseq buffer 0 num-read) scheme order)
+           :do (multiple-value-bind (enc ces-st)
+                   (ces-guess-from-vector (subseq buffer 0 num-read) scheme ces-state)
                  (setf encoding enc
-                       order ord)))
+                       ces-state ces-st)))
         encoding)
       (error (format nil "supplied stream is not a byte input stream."))))
 
@@ -137,19 +137,19 @@ method modifies `stream`'s file position."
       (let* ((buffer-length *default-buffer-size*)
              (buffer (make-array buffer-length :element-type '(unsigned-byte 8)))
              (encoding)
-             (order)
+             (ces-state)
              (end-of-line))
         (loop :named stride-over-buffer
            :for num-read := (read-sequence buffer stream)
            :if (< num-read buffer-length)
            :do (return-from stride-over-buffer
-                 (setf encoding (ces-guess-from-vector (subseq buffer 0 num-read) scheme order)
+                 (setf encoding (ces-guess-from-vector (subseq buffer 0 num-read) scheme ces-state)
                        end-of-line (eol-guess-from-vector (subseq buffer 0 num-read))))
            :else
-           :do (multiple-value-bind (enc ord)
-                   (ces-guess-from-vector (subseq buffer 0 num-read) scheme order)
+           :do (multiple-value-bind (enc ces-st)
+                   (ces-guess-from-vector (subseq buffer 0 num-read) scheme ces-state)
                  (setf encoding enc
-                       order ord)
+                       ces-state ces-st)
                  (unless end-of-line
                    (sef (eol-guess-from-vector buffer)))))
         (let ((enc-impl (dependent-name encoding))

--- a/src/inquisitor.lisp
+++ b/src/inquisitor.lisp
@@ -61,10 +61,10 @@ method modifies `stream`'s file position."
            :for num-read := (read-sequence buffer stream)
            :if (< num-read buffer-length)
            :do (return-from detect-encoding
-                 (ces-guess-from-vector (subseq buffer 0 num-read) scheme))
+                 (ces-guess-from-vector (subseq buffer 0 num-read) scheme order))
            :else
            :do (multiple-value-bind (enc ord)
-                   (ces-guess-from-vector (subseq buffer 0 num-read) scheme)
+                   (ces-guess-from-vector (subseq buffer 0 num-read) scheme order)
                  (setf encoding enc
                        order ord)))
         encoding)
@@ -143,11 +143,11 @@ method modifies `stream`'s file position."
            :for num-read := (read-sequence buffer stream)
            :if (< num-read buffer-length)
            :do (return-from stride-over-buffer
-                 (setf encoding (ces-guess-from-vector (subseq buffer 0 num-read) scheme)
+                 (setf encoding (ces-guess-from-vector (subseq buffer 0 num-read) scheme order)
                        end-of-line (eol-guess-from-vector (subseq buffer 0 num-read))))
            :else
            :do (multiple-value-bind (enc ord)
-                   (ces-guess-from-vector (subseq buffer 0 num-read) scheme)
+                   (ces-guess-from-vector (subseq buffer 0 num-read) scheme order)
                  (setf encoding enc
                        order ord)
                  (unless end-of-line

--- a/src/inquisitor.lisp
+++ b/src/inquisitor.lisp
@@ -44,6 +44,12 @@
 
 (defgeneric detect-encoding (input symbol))
 
+(defmethod detect-encoding ((buffer vector)  (scheme symbol))
+  "Detect character encoding scheme under the `scheme` from `buffer`."
+  (if (byte-array-p buffer)
+      (ces-guess-from-vector buffer scheme)
+      (error (format nil "supllied vector is not a byte array."))))
+
 (defmethod detect-encoding ((stream stream) (scheme symbol))
   "Detect character encoding scheme under the `scheme` from `stream`. Note that this
 method modifies `stream`'s file position."
@@ -71,6 +77,15 @@ method modifies `stream`'s file position."
                    :direction :input
                    :element-type '(unsigned-byte 8))
     (detect-encoding in scheme)))
+
+
+(defgeneric detect-end-of-line (input))
+
+(defmethod detect-end-of-line ((buffer vector))
+  "Detect end-of-line style from `buffer`."
+  (if (byte-array-p buffer)
+      (eol-guess-from-vector buffer)
+      (error (format nil "supllied vector is not a byte array."))))
 
 (defmethod detect-end-of-line ((stream stream))
   "Detect end-of-line style from `stream`. Note that this method modifies `stream`'s

--- a/src/inquisitor.lisp
+++ b/src/inquisitor.lisp
@@ -19,8 +19,7 @@
   (:import-from :inquisitor.util
                 :with-byte-array
                 :byte-array-p
-                :byte-input-stream-p
-                :file-position-changable-p)
+                :byte-input-stream-p)
   (:export :*detecting-buffer-size*
            :make-external-format
            :list-available-scheme

--- a/src/inquisitor.lisp
+++ b/src/inquisitor.lisp
@@ -96,35 +96,62 @@ file position."
                    :element-type '(unsigned-byte 8))
     (detect-end-of-line in)))
 
-(defmethod detect-external-format ((vec vector) (scheme symbol))
-  (if (byte-array-p vec)
-      (let (enc eol)
-        (multiple-value-bind (encoding order)
-            (ces-guess-from-vector vec scheme)
-          (declare (ignore order))
-          (setf enc (dependent-name encoding)))
-        (setf eol (eol-guess-from-vector vec))
-        (if (eq enc :cannot-treat)
-            (error (format nil "unsupported on ~a: ~{~a~^, ~}"
-                           (lisp-implementation-type) enc))
-            (if (null eol)
-                (make-external-format enc :lf)
-                (make-external-format enc eol))))
-      (error (format nil "supplied vector is not a byte array."))))
+
+(defgeneric detect-external-format (input symbol))
+
+(defmethod detect-external-format ((buffer vector) (scheme symbol))
+  "Detect external-format under the `scheme` from `buffer`."
+  (if (byte-array-p buffer)
+      (let* ((enc (ces-guess-from-vector buffer scheme))
+             (eol (eol-guess-from-vector buffer))
+             (enc-impl (dependent-name enc))
+             (eol-impl (dependent-name eol)))
+        (if (or (eq enc-impl :cannot-treat)
+                (eq eol-impl :cannot-treat))
+            (values nil (list enc eol))
+            (values
+             (if eol-impl
+                 (make-external-format enc-impl eol-impl)
+                 (make-external-format enc-impl :lf))
+             (list enc eol))))
+      (error (format nil "supllied vector is not a byte array."))))
 
 (defmethod detect-external-format ((stream stream) (scheme symbol))
+  "Detect external-format under the `scheme` from `buffer`. Note that this method
+method modifies `stream`'s file position."
   (if (byte-input-stream-p stream)
-      (if (file-position-changable-p stream)
-          (let ((pos (file-position stream)))
-            (with-byte-array (vec *detecting-buffer-size*)
-              (read-sequence vec stream)
-              (prog1
-                  (detect-external-format vec scheme)
-                (file-position stream pos))))
-          (error (format nil "supplied stream is not file-position changable.")))
+      (let* ((buffer-length *default-buffer-size*)
+             (buffer (make-array buffer-length :element-type '(unsigned-byte 8)))
+             (encoding)
+             (order)
+             (end-of-line))
+        (loop :named stride-over-buffer
+           :for num-read := (read-sequence buffer stream)
+           :if (< num-read buffer-length)
+           :do (return-from stride-over-buffer
+                 (setf encoding (ces-guess-from-vector (subseq buffer 0 num-read) scheme)
+                       end-of-line (eol-guess-from-vector (subseq buffer 0 num-read))))
+           :else
+           :do (multiple-value-bind (enc ord)
+                   (ces-guess-from-vector (subseq buffer 0 num-read) scheme)
+                 (setf encoding enc
+                       order ord)
+                 (unless end-of-line
+                   (sef (eol-guess-from-vector buffer)))))
+        (let ((enc-impl (dependent-name encoding))
+              (eol-impl (dependent-name end-of-line)))
+          (if (or (eq enc-impl :cannot-treat)
+                  (eq eol-impl :cannot-treat))
+              (values nil (list encoding end-of-line))
+              (values
+               (if eol-impl
+                   (make-external-format enc-impl eol-impl)
+                   (make-external-format enc-impl :lf))
+               (list encoding end-of-line)))))
       (error (format nil "supplied stream is not a byte input stream."))))
 
 (defmethod detect-external-format ((path pathname) (scheme symbol))
+  "Detect external-format from `pathname`."
   (with-open-file (in path
                    :direction :input
                    :element-type '(unsigned-byte 8))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -3,8 +3,7 @@
   (:use :cl)
   (:export :with-byte-array
            :byte-array-p
-           :byte-input-stream-p
-           :file-position-changable-p)
+           :byte-input-stream-p)
   (:import-from :alexandria
                 :type=))
 (in-package :inquisitor.util)
@@ -22,12 +21,3 @@
   (and (typep stream 'stream)
        (input-stream-p stream)
        (type= (stream-element-type stream) '(unsigned-byte 8))))
-
-(defun file-position-changable-p (stream)
-  (and (typep stream 'stream)
-       (input-stream-p stream)
-       (let ((pos (file-position stream)))
-         (prog1
-             (and (not (null pos))
-                  (file-position stream pos))
-           (file-position stream pos)))))

--- a/t/encoding.lisp
+++ b/t/encoding.lisp
@@ -199,15 +199,15 @@
                           :direction :input
                           :element-type '(unsigned-byte 8))
         (with-byte-array (buffer 1000)
-          (let (encoding order)
+          (let (encoding order state)
             (loop :named segmented-detection
                :for num-read := (read-sequence buffer in)
                :if (< num-read 1000)
                :do (return-from segmented-detection
-                     (ces-guess-from-vector (subseq buffer 0 num-read) :jp order))
+                     (ces-guess-from-vector (subseq buffer 0 num-read) :jp order state))
                :else
                :do (multiple-value-bind (enc ord)
-                       (ces-guess-from-vector buffer :jp order)
+                       (ces-guess-from-vector buffer :jp order state)
                      (setf encoding enc
                            order ord)))
             (setf enc-segmented encoding

--- a/t/encoding.lisp
+++ b/t/encoding.lisp
@@ -21,7 +21,7 @@
 (defun test-check-bom (actual-vec expected)
   (is (block inquisitor.encoding.guess::guess-body
         (inquisitor.encoding.guess::check-byte-order-mark
-         actual-vec :big-endian :little-endian nil))
+         actual-vec :big-endian :little-endian nil nil))
       expected))
 
 (subtest "Byte order mark treatment"

--- a/t/encoding.lisp
+++ b/t/encoding.lisp
@@ -4,9 +4,7 @@
         :inquisitor.encoding.guess
         :prove)
   (:import-from :inquisitor.util
-                :with-byte-array)
-  (:import-from :inquisitor-test.util
-                :get-test-data))
+                :with-byte-array))
 (in-package :inquisitor.encoding-test)
 
 ;; NOTE: To run this test file, execute `(asdf:test-system :inquisitor)' in your Lisp.
@@ -65,7 +63,7 @@
 
 
 (defun test-enc (path scm enc)
-  (with-open-file (in (get-test-data path)
+  (with-open-file (in (asdf:system-relative-pathname :inquisitor path)
                    :direction :input
                    :element-type '(unsigned-byte 8))
     (with-byte-array (vec (file-length in))
@@ -78,119 +76,118 @@
       '(:jp :tw :cn :kr :ru :ar :tr :gr :hw :pl :bl)))
 
 (subtest "encoding -- not supported scheme"
-  (is-error (test-enc "data/empty.txt" :not-supported :utf-8) 'error))
+  (is-error (test-enc "t/data/empty.txt" :not-supported :utf-8) 'error))
 
 (subtest "encoding -- jp"
-  (test-enc "data/ascii/empty.txt" :jp :utf-8)
-  (test-enc "data/ascii/ascii.txt" :jp :utf-8)
+  (test-enc "t/data/ascii/empty.txt" :jp :utf-8)
+  (test-enc "t/data/ascii/ascii.txt" :jp :utf-8)
 
-  (test-enc "data/ja/eucjp.txt" :jp :euc-jp)
-  (test-enc "data/ja/jis.txt" :jp :iso-2022-jp)
-  (test-enc "data/ja/sjis.txt" :jp :cp932)
+  (test-enc "t/data/ja/eucjp.txt" :jp :euc-jp)
+  (test-enc "t/data/ja/jis.txt" :jp :iso-2022-jp)
+  (test-enc "t/data/ja/sjis.txt" :jp :cp932)
 
-  (test-enc "data/unicode/utf-8.txt" :jp :utf-8)
-  (test-enc "data/unicode/ucs2be.txt" :jp :ucs-2be)
-  (test-enc "data/unicode/ucs2le.txt" :jp :ucs-2le)
-  (test-enc "data/unicode/utf-16.txt" :jp :utf-16))
+  (test-enc "t/data/unicode/utf-8.txt" :jp :utf-8)
+  (test-enc "t/data/unicode/ucs2be.txt" :jp :ucs-2be)
+  (test-enc "t/data/unicode/ucs2le.txt" :jp :ucs-2le)
+  (test-enc "t/data/unicode/utf-16.txt" :jp :utf-16))
 
 (subtest "encoding -- tw"
-  (test-enc "data/ascii/empty.txt" :tw :utf-8)
-  (test-enc "data/ascii/ascii.txt" :tw :utf-8)
+  (test-enc "t/data/ascii/empty.txt" :tw :utf-8)
+  (test-enc "t/data/ascii/ascii.txt" :tw :utf-8)
 
-  (test-enc "data/tw/big5.txt" :tw :big5)
+  (test-enc "t/data/tw/big5.txt" :tw :big5)
   (diag "iso2022 is equivalent to euc-tw, probably... (https://en.wikipedia.org/wiki/CNS_11643)")
-  (test-enc "data/tw/euctw.txt" :tw :iso-2022-tw)
+  (test-enc "t/data/tw/euctw.txt" :tw :iso-2022-tw)
 
-  (test-enc "data/unicode/utf-8.txt" :tw :utf-8))
+  (test-enc "t/data/unicode/utf-8.txt" :tw :utf-8))
 
 (subtest "encoding -- cn"
-  (test-enc "data/ascii/empty.txt" :cn :utf-8)
-  (test-enc "data/ascii/ascii.txt" :cn :utf-8)
+  (test-enc "t/data/ascii/empty.txt" :cn :utf-8)
+  (test-enc "t/data/ascii/ascii.txt" :cn :utf-8)
 
-  (test-enc "data/cn/gb2312.txt" :cn :gb2312)
-  (test-enc "data/cn/gb18030.txt" :cn :gb18030)
-  (test-enc "data/cn/iso2022cn.txt" :cn :iso-2022-cn)
+  (test-enc "t/data/cn/gb2312.txt" :cn :gb2312)
+  (test-enc "t/data/cn/gb18030.txt" :cn :gb18030)
+  (test-enc "t/data/cn/iso2022cn.txt" :cn :iso-2022-cn)
 
-  (test-enc "data/unicode/utf-8.txt" :cn :utf-8))
+  (test-enc "t/data/unicode/utf-8.txt" :cn :utf-8))
 
 (subtest "encoding -- kr"
-  (test-enc "data/ascii/empty.txt" :kr :utf-8)
-  (test-enc "data/ascii/ascii.txt" :kr :utf-8)
+  (test-enc "t/data/ascii/empty.txt" :kr :utf-8)
+  (test-enc "t/data/ascii/ascii.txt" :kr :utf-8)
 
-  (test-enc "data/kr/euckr.txt" :kr :euc-kr)
-  (test-enc "data/kr/johab.txt" :kr :johab)
-  (test-enc "data/kr/iso2022kr.txt" :kr :iso-2022-kr)
+  (test-enc "t/data/kr/euckr.txt" :kr :euc-kr)
+  (test-enc "t/data/kr/johab.txt" :kr :johab)
+  (test-enc "t/data/kr/iso2022kr.txt" :kr :iso-2022-kr)
 
-  (test-enc "data/unicode/utf-8.txt" :kr :utf-8))
+  (test-enc "t/data/unicode/utf-8.txt" :kr :utf-8))
 
 (subtest "encoding -- ar"
-  (test-enc "data/ascii/empty.txt" :ar :utf-8)
-  (test-enc "data/ascii/ascii.txt" :ar :utf-8)
+  (test-enc "t/data/ascii/empty.txt" :ar :utf-8)
+  (test-enc "t/data/ascii/ascii.txt" :ar :utf-8)
 
-  (test-enc "data/ar/iso8859-6.txt" :ar :iso-8859-6)
-  (test-enc "data/ar/cp1256.txt" :ar :cp1256)
+  (test-enc "t/data/ar/iso8859-6.txt" :ar :iso-8859-6)
+  (test-enc "t/data/ar/cp1256.txt" :ar :cp1256)
 
-  (test-enc "data/unicode/utf-8.txt" :ar :utf-8))
+  (test-enc "t/data/unicode/utf-8.txt" :ar :utf-8))
 
 (subtest "encoding -- gr"
-  (test-enc "data/ascii/empty.txt" :gr :utf-8)
-  (test-enc "data/ascii/ascii.txt" :gr :utf-8)
+  (test-enc "t/data/ascii/empty.txt" :gr :utf-8)
+  (test-enc "t/data/ascii/ascii.txt" :gr :utf-8)
 
-  (test-enc "data/gr/iso8859-7.txt" :gr :iso-8859-7)
+  (test-enc "t/data/gr/iso8859-7.txt" :gr :iso-8859-7)
   (diag "in range of greek character, cp1253 is subset of iso8859-7, probably")
-  (test-enc "data/gr/cp1253.txt" :gr :cp1253)
+  (test-enc "t/data/gr/cp1253.txt" :gr :cp1253)
 
-  (test-enc "data/unicode/utf-8.txt" :gr :utf-8))
+  (test-enc "t/data/unicode/utf-8.txt" :gr :utf-8))
 
 (subtest "encoding -- hw"
-  (test-enc "data/ascii/empty.txt" :hw :utf-8)
-  (test-enc "data/ascii/ascii.txt" :hw :utf-8)
+  (test-enc "t/data/ascii/empty.txt" :hw :utf-8)
+  (test-enc "t/data/ascii/ascii.txt" :hw :utf-8)
 
-  (test-enc "data/hw/iso8859-8.txt" :hw :iso-8859-8)
-  (test-enc "data/hw/cp1255.txt" :hw :cp1255)
+  (test-enc "t/data/hw/iso8859-8.txt" :hw :iso-8859-8)
+  (test-enc "t/data/hw/cp1255.txt" :hw :cp1255)
 
   (diag "*TODO!* iso8859-8 does not has vowels (called 'nikud'), thus that case must be added.")
 
-  (test-enc "data/unicode/utf-8.txt" :hw :utf-8))
+  (test-enc "t/data/unicode/utf-8.txt" :hw :utf-8))
 
 (subtest "encoding -- tr"
-  (test-enc "data/ascii/empty.txt" :tr :utf-8)
-  (test-enc "data/ascii/ascii.txt" :tr :utf-8)
+  (test-enc "t/data/ascii/empty.txt" :tr :utf-8)
+  (test-enc "t/data/ascii/ascii.txt" :tr :utf-8)
 
-  (test-enc "data/tr/iso8859-9.txt" :tr :iso-8859-9)
-  (test-enc "data/tr/cp1254.txt" :tr :cp1254)
+  (test-enc "t/data/tr/iso8859-9.txt" :tr :iso-8859-9)
+  (test-enc "t/data/tr/cp1254.txt" :tr :cp1254)
 
-  (test-enc "data/unicode/utf-8.txt" :tr :utf-8))
+  (test-enc "t/data/unicode/utf-8.txt" :tr :utf-8))
 
 (subtest "encoding -- ru"
-  (test-enc "data/ascii/empty.txt" :ru :utf-8)
-  (test-enc "data/ascii/ascii.txt" :ru :utf-8)
+  (test-enc "t/data/ascii/empty.txt" :ru :utf-8)
+  (test-enc "t/data/ascii/ascii.txt" :ru :utf-8)
 
-  (test-enc "data/ru/iso8859-5.txt" :ru :iso-8859-5)
-  (test-enc "data/ru/koi8r.txt" :ru :koi8-r)
-  (test-enc "data/ru/koi8u.txt" :ru :koi8-u)
-  (test-enc "data/ru/cp866.txt" :ru :cp866)
-  (test-enc "data/ru/cp1251.txt" :ru :cp1251)
+  (test-enc "t/data/ru/iso8859-5.txt" :ru :iso-8859-5)
+  (test-enc "t/data/ru/koi8r.txt" :ru :koi8-r)
+  (test-enc "t/data/ru/koi8u.txt" :ru :koi8-u)
+  (test-enc "t/data/ru/cp866.txt" :ru :cp866)
+  (test-enc "t/data/ru/cp1251.txt" :ru :cp1251)
 
-  (test-enc "data/unicode/utf-8.txt" :ru :utf-8))
+  (test-enc "t/data/unicode/utf-8.txt" :ru :utf-8))
 
 (subtest "encoding -- pl"
-  (test-enc "data/ascii/empty.txt" :pl :utf-8)
-  (test-enc "data/ascii/ascii.txt" :pl :utf-8)
+  (test-enc "t/data/ascii/empty.txt" :pl :utf-8)
+  (test-enc "t/data/ascii/ascii.txt" :pl :utf-8)
 
-  (test-enc "data/pl/iso8859-2.txt" :pl :iso-8859-2)
-  (test-enc "data/pl/cp1250.txt" :pl :cp1250)
+  (test-enc "t/data/pl/iso8859-2.txt" :pl :iso-8859-2)
+  (test-enc "t/data/pl/cp1250.txt" :pl :cp1250)
 
-  (test-enc "data/unicode/utf-8.txt" :pl :utf-8))
+  (test-enc "t/data/unicode/utf-8.txt" :pl :utf-8))
 
 (subtest "encoding -- bl"
-  (test-enc "data/ascii/empty.txt" :bl :utf-8)
-  (test-enc "data/ascii/ascii.txt" :bl :utf-8)
+  (test-enc "t/data/ascii/empty.txt" :bl :utf-8)
+  (test-enc "t/data/ascii/ascii.txt" :bl :utf-8)
 
-  (test-enc "data/bl/iso8859-13.txt" :bl :iso-8859-13)
-  (test-enc "data/bl/cp1257.txt" :bl :cp1257)
+  (test-enc "t/data/bl/iso8859-13.txt" :bl :iso-8859-13)
+  (test-enc "t/data/bl/cp1257.txt" :bl :cp1257)
 
-  (test-enc "data/unicode/utf-8.txt" :bl :utf-8))
-
+  (test-enc "t/data/unicode/utf-8.txt" :bl :utf-8))
 
 (finalize)

--- a/t/encoding.lisp
+++ b/t/encoding.lisp
@@ -70,13 +70,7 @@
                    :element-type '(unsigned-byte 8))
     (with-byte-array (vec (file-length in))
       (read-sequence vec in)
-      (multiple-value-bind (encoding treatable)
-          (ces-guess-from-vector vec scm)
-        (is encoding enc)
-        (when treatable
-          (diag (format nil " ; ~a cannot treat ~a"
-                        (lisp-implementation-type)
-                        encoding)))))))
+      (is (ces-guess-from-vector vec scm) enc))))
 
 
 (subtest "list available schemes"

--- a/t/encoding.lisp
+++ b/t/encoding.lisp
@@ -21,8 +21,9 @@
   (apply #'vector (mapcar (lambda (c) (char-code c)) (coerce s 'list))))
 
 (defun test-check-bom (actual-vec expected)
-  (is (inquisitor.encoding.guess::%check-byte-order-mark actual-vec
-                                                        (length actual-vec))
+  (is (block inquisitor.encoding.guess::guess-body
+        (inquisitor.encoding.guess::check-byte-order-mark
+         actual-vec :big-endian :little-endian nil))
       expected))
 
 (subtest "Byte order mark treatment"

--- a/t/eol.lisp
+++ b/t/eol.lisp
@@ -4,9 +4,7 @@
         :inquisitor.eol
         :prove)
   (:import-from :inquisitor.util
-                :with-byte-array)
-  (:import-from :inquisitor-test.util
-                :get-test-data))
+                :with-byte-array))
 (in-package :inquisitor.eol-test)
 
 ;; NOTE: To run this test file, execute `(asdf:test-system :inquisitor)' in your Lisp.
@@ -15,7 +13,7 @@
 
 
 (defun test-eol (path eol)
-  (with-open-file (in (get-test-data path)
+  (with-open-file (in (asdf:system-relative-pathname :inquisitor path)
                       :direction :input
                       :element-type '(unsigned-byte 8))
     (with-byte-array (vec (file-length in))
@@ -23,14 +21,14 @@
       (is (eol-guess-from-vector vec) eol))))
 
 
-(test-eol "data/ascii/ascii-cr.txt" :cr)
-(test-eol "data/ascii/ascii-crlf.txt" :crlf)
-(test-eol "data/ascii/ascii-lf.txt" :lf)
-(test-eol "data/ascii/ascii-lfcr.txt" :lf)
+(test-eol "t/data/ascii/ascii-cr.txt" :cr)
+(test-eol "t/data/ascii/ascii-crlf.txt" :crlf)
+(test-eol "t/data/ascii/ascii-lf.txt" :lf)
+(test-eol "t/data/ascii/ascii-lfcr.txt" :lf)
 
 (subtest "If file has no newline then return NIL"
-  (test-eol "data/ascii/ascii.txt" nil)
-  (test-eol "data/ascii/empty.txt" nil))
+  (test-eol "t/data/ascii/ascii.txt" nil)
+  (test-eol "t/data/ascii/empty.txt" nil))
 
 
 (finalize)

--- a/t/inquisitor.lisp
+++ b/t/inquisitor.lisp
@@ -29,10 +29,11 @@
       (is-error (detect-encoding in :jp) 'error))
 
     (with-open-file (in (asdf:system-relative-pathname
-                         :inquisitor "t/data/ascii/ascii-lf.txt")
+                         :inquisitor "t/data/unicode/utf-8.txt")
                         :direction :input
                         :element-type '(unsigned-byte 8))
-      (is (detect-encoding in :jp) :utf-8)))
+      (is (detect-encoding in :jp) :utf-8)
+      (is (file-position in) (file-length in))))
 
   (subtest "for pathname"
     (is (detect-encoding (asdf:system-relative-pathname
@@ -52,10 +53,13 @@
                         :direction :input)
       (is-error (detect-end-of-line in) 'error))
 
-    (with-open-file (in (asdf:system-relative-pathname :inquisitor "t/data/ascii/ascii-lf.txt")
+    (with-open-file (in (asdf:system-relative-pathname
+                         :inquisitor "t/data/unicode/utf-8.txt")
                         :direction :input
                         :element-type '(unsigned-byte 8))
-      (is (detect-end-of-line in) :lf)))
+      (is (detect-end-of-line in) :lf)
+      (diag "is this check valid?")
+      (is (file-position in) (file-length in))))
 
   (subtest "for pathname"
     (is (detect-end-of-line (asdf:system-relative-pathname :inquisitor "t/data/ascii/ascii-lf.txt"))

--- a/t/inquisitor.lisp
+++ b/t/inquisitor.lisp
@@ -23,9 +23,7 @@
     (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
                         :direction :input
                         :element-type '(unsigned-byte 8))
-      (let ((pos (file-position in)))
-        (is (detect-encoding in :jp) :utf-8)
-        (is (file-position in) pos))))
+      (is (detect-encoding in :jp) :utf-8)))
 
   (subtest "for pathname"
     (is (detect-encoding (get-test-data "data/ascii/ascii-lf.txt") :jp) :utf-8)))
@@ -39,9 +37,7 @@
     (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
                         :direction :input
                         :element-type '(unsigned-byte 8))
-      (let ((pos (file-position in)))
-        (is (detect-end-of-line in) :lf)
-        (is (file-position in) pos))))
+      (is (detect-end-of-line in) :lf)))
 
   (subtest "for pathname"
     (is (detect-end-of-line (get-test-data "data/ascii/ascii-lf.txt"))
@@ -64,10 +60,8 @@
   (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
                       :direction :input
                       :element-type '(unsigned-byte 8))
-    (let ((pos (file-position in)))
-      (is (detect-external-format in :jp)
-          (make-external-format :utf-8 :lf))
-      (is (file-position in) pos))))
+    (is (detect-external-format in :jp)
+        (make-external-format :utf-8 :lf))))
 
 (subtest "detect external-format --- from pathname"
   (is-error (detect-external-format "data/ascii/ascii-lf.txt" :jp) 'error)

--- a/t/inquisitor.lisp
+++ b/t/inquisitor.lisp
@@ -19,10 +19,6 @@
     (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
                         :direction :input)
       (is-error (detect-encoding in :jp) 'error))
-    (let ((s (drakma:http-request "http://cliki.net"
-                                  :want-stream t
-                                  :force-binary t)))
-      (is-error (detect-encoding s :jp) 'error))
 
     (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
                         :direction :input
@@ -39,10 +35,6 @@
     (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
                         :direction :input)
       (is-error (detect-end-of-line in) 'error))
-    (let ((s (drakma:http-request "http://cliki.net"
-                                  :want-stream t
-                                  :force-binary t)))
-      (is-error (detect-end-of-line s) 'error))
 
     (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
                         :direction :input

--- a/t/inquisitor.lisp
+++ b/t/inquisitor.lisp
@@ -15,6 +15,14 @@
 
 
 (subtest "detect-encoding"
+  (subtest "for vector"
+    (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
+                        :direction :input
+                        :element-type '(unsigned-byte 8))
+      (let ((buffer (make-array (file-length in) :element-type '(unsigned-byte 8))))
+        (read-sequence buffer in)
+        (is (detect-encoding buffer :jp) :utf-8))))
+
   (subtest "for stream"
     (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
                         :direction :input)
@@ -29,6 +37,14 @@
     (is (detect-encoding (get-test-data "data/ascii/ascii-lf.txt") :jp) :utf-8)))
 
 (subtest "detect-end-of-line"
+  (subtest "for vector"
+    (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
+                        :direction :input
+                        :element-type '(unsigned-byte 8))
+      (let ((buffer (make-array (file-length in) :element-type '(unsigned-byte 8))))
+        (read-sequence buffer in)
+        (is (detect-end-of-line buffer) :lf))))
+
   (subtest "for stream"
     (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
                         :direction :input)

--- a/t/inquisitor.lisp
+++ b/t/inquisitor.lisp
@@ -3,8 +3,6 @@
   (:use :cl
         :inquisitor
         :prove)
-  (:import-from :inquisitor-test.util
-                :get-test-data)
   (:import-from :babel
                 :string-to-octets))
 (in-package :inquisitor-test)
@@ -16,7 +14,8 @@
 
 (subtest "detect-encoding"
   (subtest "for vector"
-    (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
+    (with-open-file (in (asdf:system-relative-pathname
+                         :inquisitor "t/data/ascii/ascii-lf.txt")
                         :direction :input
                         :element-type '(unsigned-byte 8))
       (let ((buffer (make-array (file-length in) :element-type '(unsigned-byte 8))))
@@ -24,21 +23,24 @@
         (is (detect-encoding buffer :jp) :utf-8))))
 
   (subtest "for stream"
-    (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
+    (with-open-file (in (asdf:system-relative-pathname
+                         :inquisitor "t/data/ascii/ascii-lf.txt")
                         :direction :input)
       (is-error (detect-encoding in :jp) 'error))
 
-    (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
+    (with-open-file (in (asdf:system-relative-pathname
+                         :inquisitor "t/data/ascii/ascii-lf.txt")
                         :direction :input
                         :element-type '(unsigned-byte 8))
       (is (detect-encoding in :jp) :utf-8)))
 
   (subtest "for pathname"
-    (is (detect-encoding (get-test-data "data/ascii/ascii-lf.txt") :jp) :utf-8)))
+    (is (detect-encoding (asdf:system-relative-pathname
+                         :inquisitor "t/data/ascii/ascii-lf.txt") :jp) :utf-8)))
 
 (subtest "detect-end-of-line"
   (subtest "for vector"
-    (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
+    (with-open-file (in (asdf:system-relative-pathname :inquisitor "t/data/ascii/ascii-lf.txt")
                         :direction :input
                         :element-type '(unsigned-byte 8))
       (let ((buffer (make-array (file-length in) :element-type '(unsigned-byte 8))))
@@ -46,17 +48,17 @@
         (is (detect-end-of-line buffer) :lf))))
 
   (subtest "for stream"
-    (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
+    (with-open-file (in (asdf:system-relative-pathname :inquisitor "t/data/ascii/ascii-lf.txt")
                         :direction :input)
       (is-error (detect-end-of-line in) 'error))
 
-    (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
+    (with-open-file (in (asdf:system-relative-pathname :inquisitor "t/data/ascii/ascii-lf.txt")
                         :direction :input
                         :element-type '(unsigned-byte 8))
       (is (detect-end-of-line in) :lf)))
 
   (subtest "for pathname"
-    (is (detect-end-of-line (get-test-data "data/ascii/ascii-lf.txt"))
+    (is (detect-end-of-line (asdf:system-relative-pathname :inquisitor "t/data/ascii/ascii-lf.txt"))
         :lf)))
 
 (subtest "detect external-format --- from vector"
@@ -73,15 +75,16 @@
     (is-error (detect-external-format out :jp) 'error))
   (with-input-from-string (in "string")
     (is-error (detect-external-format in :jp) 'error))
-  (with-open-file (in (get-test-data "data/ascii/ascii-lf.txt")
+  (with-open-file (in (asdf:system-relative-pathname :inquisitor "t/data/ascii/ascii-lf.txt")
                       :direction :input
                       :element-type '(unsigned-byte 8))
     (is (detect-external-format in :jp)
         (make-external-format :utf-8 :lf))))
 
 (subtest "detect external-format --- from pathname"
-  (is-error (detect-external-format "data/ascii/ascii-lf.txt" :jp) 'error)
-  (is (detect-external-format (get-test-data "data/ascii/ascii-lf.txt") :jp)
+  (is-error (detect-external-format "t/data/ascii/ascii-lf.txt" :jp) 'error)
+  (is (detect-external-format (asdf:system-relative-pathname
+                               :inquisitor "t/data/ascii/ascii-lf.txt") :jp)
       (make-external-format :utf-8 :lf)))
 
 

--- a/t/test-util.lisp
+++ b/t/test-util.lisp
@@ -1,8 +1,0 @@
-(in-package :cl-user)
-(defpackage inquisitor-test.util
-  (:use :cl))
-(in-package :inquisitor-test.util)
-
-
-(defun get-test-data (pathname)
-  (merge-pathnames pathname *load-truename*))

--- a/t/util.lisp
+++ b/t/util.lisp
@@ -4,9 +4,7 @@
         :inquisitor.util
         :prove)
   (:import-from :inquisitor.util
-                :with-byte-array)
-  (:import-from :inquisitor-test.util
-                :get-test-data))
+                :with-byte-array))
 (in-package :inquisitor.util-test)
 
 ;; NOTE: To run this test file, execute `(asdf:test-system :inquisitor)' in your Lisp.
@@ -45,13 +43,13 @@
       (ok (not (byte-input-stream-p out))))
     (with-input-from-string (in "string")
       (ok (not (byte-input-stream-p in))))
-    (with-open-file (in (get-test-data "data/ascii/ascii.txt")
+    (with-open-file (in (asdf:system-relative-pathname :inquisitor "t/data/ascii/ascii.txt")
                         :direction :input
                         :element-type 'character)
       (ok (not (byte-input-stream-p in)))))
 
   (subtest "return t"
-    (with-open-file (in (get-test-data "data/ascii/ascii.txt")
+    (with-open-file (in (asdf:system-relative-pathname :inquisitor "t/data/ascii/ascii.txt")
                         :direction :input
                         :element-type '(unsigned-byte 8))
       (ok (byte-input-stream-p in)))))

--- a/t/util.lisp
+++ b/t/util.lisp
@@ -11,7 +11,7 @@
 
 ;; NOTE: To run this test file, execute `(asdf:test-system :inquisitor)' in your Lisp.
 
-(plan 4)
+(plan 3)
 
 
 (subtest "with-byte-array"
@@ -55,27 +55,6 @@
                         :direction :input
                         :element-type '(unsigned-byte 8))
       (ok (byte-input-stream-p in)))))
-
-(subtest "file-position-changable-p"
-  (subtest "return nil"
-    (ok (not (file-position-changable-p "string")))
-    (with-output-to-string (out)
-      (ok (not (file-position-changable-p out))))
-    (let ((s (drakma:http-request "http://cliki.net"
-                                  :want-stream t)))
-      (ok (not (file-position-changable-p s))))
-
-  (subtest "return t"
-    (with-open-file (in (get-test-data "data/ascii/empty.txt")
-                        :direction :input)
-      (ok (file-position-changable-p in)))
-    
-    (with-open-file (in (get-test-data "data/ascii/ascii.txt")
-                        :direction :input)
-      (let ((pos (file-position in)))
-        (ok (file-position-changable-p in))
-        (diag "check file-position not be changed")
-        (is (file-position in) pos))))))
 
 
 (finalize)


### PR DESCRIPTION
This PR is caused by @cxxxr 's PR https://github.com/t-sin/inquisitor/pull/43 , that removes `*detecting-buffer-size*`. 

`*detecting-buffer-size*` means that, `(detect-*` (stream))` reads only the number of bytes, without checking whole stream. This make low precision of encoding/end-of-line detection. This problem is issued in https://github.com/t-sin/inquisitor/issues/19 .

## Changes

For this issue, this PR has some changes. I will list bellow:

- `(detect-* (stream))` runs over whole stream
- adds `(detect-* (vector))` 
- inquisitor changesstreams file position
- adds some documentation strings

## Future works

- eol detection needs encoding information
    - because of eol defined in each encoding scheme
- eol detection process
    - now, inquisitor checks first appearance of eol characters
