### PR TITLE
Supports Allegro CL and LispWorks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - LISP=abcl
     - LISP=clisp
     - LISP=ecl
+    - LISP=alisp
 
 install:
   - curl -L https://raw.githubusercontent.com/roswell/roswell/release/scripts/install-for-ci.sh | sh

--- a/src/names.lisp
+++ b/src/names.lisp
@@ -14,7 +14,8 @@
   `(;;; unicode
     ((:utf-8 . :unicode) .
      #+clisp ,charset:utf-8
-     #-clisp :utf-8)
+     #+allegro :utf8
+     #-(or clisp allegro) :utf-8)
     ((:ucs-2le . :unicode) .
      #+clisp ,charset:unicode-16-little-endian
      #+allegro :cannot-treat

--- a/src/names.lisp
+++ b/src/names.lisp
@@ -29,7 +29,7 @@
      #+ecl :utf-16
      #+ccl :utf-16
      #+abcl :utf-16
-     #-(or clisp ecl ccl abcl alleg) :cannot-treat)
+     #-(or clisp ecl ccl abcl) :cannot-treat)
 
     ;;; japanese
     ((:iso-2022-jp . :jp) .  ; jis

--- a/src/names.lisp
+++ b/src/names.lisp
@@ -17,44 +17,49 @@
      #-clisp :utf-8)
     ((:ucs-2le . :unicode) .
      #+clisp ,charset:unicode-16-little-endian
-     #-clisp :utf-16le)
+     #+allegro :cannot-treat
+     #-(or clisp allegro) :utf-16le)
     ((:ucs-2be . :unicode) .
      #+clisp ,charset:unicode-16-big-endian
-     #-clisp :utf-16be)
+     #+allegro :cannot-treat
+     #-(or clisp allegro) :utf-16be)
     ((:utf-16 . :unicode) .
      #+clisp ,charset:utf-16
      #+ecl :utf-16
      #+ccl :utf-16
      #+abcl :utf-16
-     #-(or clisp ecl ccl abcl) :cannot-treat)
+     #-(or clisp ecl ccl abcl alleg) :cannot-treat)
 
     ;;; japanese
     ((:iso-2022-jp . :jp) .  ; jis
-     ;; #+allegro :jis
      ;; #+lispworks :jis
      #+clisp ,charset:iso-2022-jp
      #+ecl :cannot-treat
      #+abcl :iso-2022-jp
-     #-(or clisp ecl abcl) :cannot-treat)
+     #+allegro :jis
+     #-(or clisp ecl abcl allegro) :cannot-treat)
     ((:euc-jp . :jp) .
      ;; #+lispworks :euc-jp
      #+clisp ,charset:euc-jp
      #+ecl :cannot-treat
-     #-(or clisp ecl) :euc-jp)
+     #+allegro :euc
+     #-(or clisp ecl allegro) :euc-jp)
     ((:cp932 . :jp) .
      ;; #+lispworks :sjis
      #+clisp ,charset:cp932
      #+ecl :windows-cp932
      #+sbcl :shift_jis
      #+ccl :windows-31j
-     #+abcl :|x-MS932_0213|)
+     #+abcl :|x-MS932_0213|
+     #+allegro :shiftjis)
 
     ;;; taiwanese
     ((:big5 . :tw) .
      #+clisp ,charset:big5
      #+ecl :windows-cp950
      #+abcl :|Big5|
-     #-(or clisp ecl abcl) :cannot-treat)
+     #+allegro :big5
+     #-(or clisp ecl abcl allegro) :cannot-treat)
     ((:iso-2022-tw :tw) .
      #+clisp ,charset:euc-tw
      #+abcl :|x-EUC-TW|
@@ -66,11 +71,13 @@
      #+ecl :windows-cp936
      #+sbcl :gbk
      #+ccl :cp936
-     #+abcl :gbk)
+     #+abcl :gbk
+     #+allegro :cannot-treat)
     ((:gb18030 . :cn) .
      #+clisp ,charset:gb18030
      #+abcl :gb18030
-     #-(or clisp abcl) :cannot-treat)
+     #+allegro :gb18030
+     #-(or clisp abcl allegro) :cannot-treat)
     ((:iso-2022-cn . :cn) .
      #+clisp ,charset:iso-2022-cn
      #+abcl :iso-2022-cn
@@ -80,13 +87,14 @@
     ((:euc-kr . :kr) .
      #+clisp ,charset:euc-kr
      #+ecl :windows-cp949
+     #+allegro :949
      #+(or sbcl ccl) :cannot-treat
-     #-(or clisp ecl sbcl ccl) :euc-kr)
+     #-(or clisp ecl sbcl ccl allegro) :euc-kr)
     ((:johab . :kr) .
      #+clisp ,charset:johab
      #+abcl :|x-Johab|
-     #+(or ecl sbcl ccl) :cannot-treat
-     #-(or clisp ecl sbcl ccl abcl) :johab)
+     #+(or ecl sbcl ccl allegro) :cannot-treat
+     #-(or clisp ecl sbcl ccl abcl allegro) :johab)
     ((:iso-2022-kr . :kr) .
      #+clisp ,charset:iso-2022-kr
      #+abcl :iso-2022-kr
@@ -95,51 +103,60 @@
     ;;; arabic
     ((:iso-8859-6 . :ar) .
      #+clisp ,charset:iso-8859-6
-     #-clisp :iso-8859-6)
+     #+allegro :iso8859-6
+     #-(or clisp allegro) :iso-8859-6)
     ((:cp1256 . :ar) .
      #+clisp ,charset:cp1256
      #+ecl :windows-cp1256
      #+ccl :cannot-treat
      #+abcl :|windows-1256|
-     #-(or clisp ecl ccl abcl) :cp1256)
+     #+allegro :1256
+     #-(or clisp ecl ccl abcl allegro) :cp1256)
 
     ;;; greek
     ((:iso-8859-7 . :gr) .
      #+clisp ,charset:iso-8859-7
-     #-clisp :iso-8859-7)
+     #+allegro :iso8859-7
+     #-(or clisp allegro) :iso-8859-7)
     ((:cp1253 . :gr) .
      #+clisp ,charset:cp1253
      #+ecl :windows-cp1253
      #+ccl :cannot-treat
      #+abcl  :|windows-1253|
-     #-(or clisp ecl ccl abcl) :cp1253)
+     #+allegro :1253
+     #-(or clisp ecl ccl abcl allegro) :cp1253)
 
     ;;; hebrew
     ((:iso-8859-8 . :hw) .
      #+clisp ,charset:iso-8859-8
-     #-clisp :iso-8859-8)
+     #+allegro :iso8559-8
+     #-(or clisp allegro) :iso-8859-8)
     ((:cp1255 . :hw) .
      #+clisp ,charset:cp1255
      #+ecl :windows-cp1255
      #+ccl :cannot-treat
      #+abcl :|windows-1255|
-     #-(or clisp ecl ccl abcl) :cp1255)
+     #+allegro :1255
+     #-(or clisp ecl ccl abcl allegro) :cp1255)
 
     ;;; turkish
     ((:iso-8859-9 . :tr) .
      #+clisp ,charset:iso-8859-9
-     #-clisp :iso-8859-9)
+     #+allegro :iso8859-9
+     #-(or clisp allegro) :iso-8859-9)
     ((:cp1254 . :tr) .
      #+clisp ,charset:cp1254
      #+ecl :windows-cp1254
      #+ccl :cannot-treat
      #+abcl :|windows-1254|
-     #-(or clisp ecl ccl abcl) :cp1254)
+     #+allegro :1254
+     #-(or clisp ecl ccl abcl allegro) :cp1254)
 
     ;;; russian
     ((:iso-8859-5 . :ru) .
      #+clisp ,charset:iso-8859-5
-     #-clisp :iso-8859-5)
+     #+allegro :iso8859-5
+     #-(or clisp allegro) :iso-8859-5)
     ((:koi8-r . :ru) .
      #+clisp ,charset:koi8-r
      #+sbcl :koi8-r
@@ -147,42 +164,48 @@
      #-(or clisp sbcl ecl ccl) :koi8-r)
     ((:koi8-u . :ru) .
      #+clisp ,charset:koi8-u
-     #+(or ecl ccl) :cannot-treat
-     #-(or clisp ecl ccl) :koi8-u)
+     #+(or ecl ccl allegro) :cannot-treat
+     #-(or clisp ecl ccl allegro) :koi8-u)
     ((:cp866 . :ru) .
      #+clisp ,charset:cp866
      #+ecl :dos-cp866
      #+ccl :cannot-treat
      #+abcl :ibm866
+     #+allegro :cannot-treat
      #-(or clisp ecl ccl abcl) :cp866)
     ((:cp1251 . :ru) .
      #+clisp ,charset:cp1251
      #+ecl :windows-cp1251
      #+ccl :cannot-treat
      #+abcl :|windows-1251|
-     #-(or clisp ecl ccl abcl) :cp1251)
+     #+allegro :1251
+     #-(or clisp ecl ccl abcl allegro) :cp1251)
 
     ;;; polish
     ((:iso-8859-2 . :pl) .
      #+clisp ,charset:iso-8859-2
-     #-clisp :iso-8859-2)
+     #+allegro :iso8859-2
+     #-(or clisp allegro) :iso-8859-2)
     ((:cp1250 . :pl) .
      #+clisp ,charset:cp1250
      #+ecl :windows-cp1250
      #+ccl :cannot-treat
      #+abcl :|windows-1250|
-     #-(or clisp ecl ccl abcl) :cp1250)
+     #+allegro :1250
+     #-(or clisp ecl ccl abcl allegro) :cp1250)
 
     ;;; baltic
     ((:iso-8859-13 . :bl) .
      #+clisp ,charset:iso-8859-13
+     #+allegro :cannot-treat
      #-clisp :iso-8859-13)
     ((:cp1257 . :bl) .
      #+clisp ,charset:cp1257
      #+ecl :windows-cp1257
      #+ccl :cannot-treat
      #+abcl :|windows-1257|
-     #-(or clisp ecl ccl abcl) :cp1257)
+     #+allegro :1257
+     #-(or clisp ecl ccl abcl allegro) :cp1257)
 
     ;;; end of line
     ((:lf . :eol) .
@@ -190,19 +213,22 @@
      #+clisp :unix
      #+sbcl :cannot-treat
      #+ccl :unix
-     #-(or clisp sbcl ccl) :lf)
+     #+allegro :unix
+     #-(or clisp sbcl ccl allegro) :lf)
     ((:cr . :eol) .
      ;; #+lispworks :cr
      #+clisp :mac
      #+sbcl :cannot-treat
      #+ccl :macos
-     #-(or clisp sbcl ccl) :cr)
+     #+allegro :mac
+     #-(or clisp sbcl allegro) :cr)
     ((:crlf . :eol) .
      ;; #+lispworks :crlf
      #+clisp :dos
      #+sbcl :cannot-treat
      #+ccl :dos
-     #-(or clisp sbcl ccl) :crlf)))
+     #+allegro :dos
+     #-(or clisp sbcl ccl allegro) :crlf)))
 
 (defvar +available-encodings+
   (loop

--- a/src/names.lisp
+++ b/src/names.lisp
@@ -19,11 +19,13 @@
     ((:ucs-2le . :unicode) .
      #+clisp ,charset:unicode-16-little-endian
      #+allegro :cannot-treat
-     #-(or clisp allegro) :utf-16le)
+     #+lispworks '(unicode :little-endian)
+     #-(or clisp allegro lispworks) :utf-16le)
     ((:ucs-2be . :unicode) .
      #+clisp ,charset:unicode-16-big-endian
      #+allegro :cannot-treat
-     #-(or clisp allegro) :utf-16be)
+     #+lispworks '(unicode :big-endian)
+     #-(or clisp allegro lispworks) :utf-16be)
     ((:utf-16 . :unicode) .
      #+clisp ,charset:utf-16
      #+ecl :utf-16
@@ -38,13 +40,15 @@
      #+ecl :cannot-treat
      #+abcl :iso-2022-jp
      #+allegro :jis
-     #-(or clisp ecl abcl allegro) :cannot-treat)
+     #+lispworks :jis
+     #-(or clisp ecl abcl allegro lispworks) :cannot-treat)
     ((:euc-jp . :jp) .
      ;; #+lispworks :euc-jp
      #+clisp ,charset:euc-jp
      #+ecl :cannot-treat
      #+allegro :euc
-     #-(or clisp ecl allegro) :euc-jp)
+     #+lispworks :euc-jp
+     #-(or clisp ecl allegro lispworks) :euc-jp)
     ((:cp932 . :jp) .
      ;; #+lispworks :sjis
      #+clisp ,charset:cp932
@@ -52,7 +56,8 @@
      #+sbcl :shift_jis
      #+ccl :windows-31j
      #+abcl :|x-MS932_0213|
-     #+allegro :shiftjis)
+     #+allegro :shiftjis
+     #+lispworks :sjis)
 
     ;;; taiwanese
     ((:big5 . :tw) .
@@ -73,7 +78,8 @@
      #+sbcl :gbk
      #+ccl :cp936
      #+abcl :gbk
-     #+allegro :cannot-treat)
+     #+allegro :cannot-treat
+     #+lispworks :gbk)
     ((:gb18030 . :cn) .
      #+clisp ,charset:gb18030
      #+abcl :gb18030
@@ -89,12 +95,13 @@
      #+clisp ,charset:euc-kr
      #+ecl :windows-cp949
      #+allegro :949
+     #+(and lispworks windows) '(win32:code-page :id 949)
      #+(or sbcl ccl) :cannot-treat
      #-(or clisp ecl sbcl ccl allegro) :euc-kr)
     ((:johab . :kr) .
      #+clisp ,charset:johab
      #+abcl :|x-Johab|
-     #+(or ecl sbcl ccl allegro) :cannot-treat
+     #+(or ecl sbcl ccl allegro lispworks) :cannot-treat
      #-(or clisp ecl sbcl ccl abcl allegro) :johab)
     ((:iso-2022-kr . :kr) .
      #+clisp ,charset:iso-2022-kr
@@ -105,131 +112,147 @@
     ((:iso-8859-6 . :ar) .
      #+clisp ,charset:iso-8859-6
      #+allegro :iso8859-6
-     #-(or clisp allegro) :iso-8859-6)
+     #+lispworks :cannot-treat
+     #-(or clisp allegro lispworks) :iso-8859-6)
     ((:cp1256 . :ar) .
      #+clisp ,charset:cp1256
      #+ecl :windows-cp1256
      #+ccl :cannot-treat
      #+abcl :|windows-1256|
      #+allegro :1256
-     #-(or clisp ecl ccl abcl allegro) :cp1256)
+     #+(and lispworks windows) '(win32:code-page :id 1256)
+     #-(or clisp ecl ccl abcl allegro lispworks) :cp1256)
 
     ;;; greek
     ((:iso-8859-7 . :gr) .
      #+clisp ,charset:iso-8859-7
      #+allegro :iso8859-7
-     #-(or clisp allegro) :iso-8859-7)
+     #+lispworks :cannot-treat
+     #-(or clisp allegro lispworks) :iso-8859-7)
     ((:cp1253 . :gr) .
      #+clisp ,charset:cp1253
      #+ecl :windows-cp1253
      #+ccl :cannot-treat
      #+abcl  :|windows-1253|
      #+allegro :1253
-     #-(or clisp ecl ccl abcl allegro) :cp1253)
+     #+(and lispworks windows) '(win32:code-page :id 1253)
+     #-(or clisp ecl ccl abcl allegro lispworks) :cp1253)
 
     ;;; hebrew
     ((:iso-8859-8 . :hw) .
      #+clisp ,charset:iso-8859-8
      #+allegro :iso8559-8
-     #-(or clisp allegro) :iso-8859-8)
+     #+lispworks :cannot-treat
+     #-(or clisp allegro lispworks) :iso-8859-8)
     ((:cp1255 . :hw) .
      #+clisp ,charset:cp1255
      #+ecl :windows-cp1255
      #+ccl :cannot-treat
      #+abcl :|windows-1255|
      #+allegro :1255
-     #-(or clisp ecl ccl abcl allegro) :cp1255)
+     #+(and lispworks windows) '(win32:code-page :id 1255)
+     #-(or clisp ecl ccl abcl allegro lispworks) :cp1255)
 
     ;;; turkish
     ((:iso-8859-9 . :tr) .
      #+clisp ,charset:iso-8859-9
      #+allegro :iso8859-9
-     #-(or clisp allegro) :iso-8859-9)
+     #+lispworks :cannot-treat
+     #-(or clisp allegro lispworks) :iso-8859-9)
     ((:cp1254 . :tr) .
      #+clisp ,charset:cp1254
      #+ecl :windows-cp1254
      #+ccl :cannot-treat
      #+abcl :|windows-1254|
      #+allegro :1254
-     #-(or clisp ecl ccl abcl allegro) :cp1254)
+     #+(and lispworks windows) '(win32:code-page :id 1254)
+     #-(or clisp ecl ccl abcl allegro lispworks) :cp1254)
 
     ;;; russian
     ((:iso-8859-5 . :ru) .
      #+clisp ,charset:iso-8859-5
      #+allegro :iso8859-5
-     #-(or clisp allegro) :iso-8859-5)
+     #+lispworks :cannot-treat
+     #-(or clisp allegro lispworks) :iso-8859-5)
     ((:koi8-r . :ru) .
      #+clisp ,charset:koi8-r
      #+sbcl :koi8-r
-     #+(or ecl ccl) :cannot-treat
+     #+(or ecl ccl lispworks) :cannot-treat
      #-(or clisp sbcl ecl ccl) :koi8-r)
     ((:koi8-u . :ru) .
      #+clisp ,charset:koi8-u
-     #+(or ecl ccl allegro) :cannot-treat
-     #-(or clisp ecl ccl allegro) :koi8-u)
+     #+(or ecl ccl allegro lispworks) :cannot-treat
+     #-(or clisp ecl ccl allegro lispworks) :koi8-u)
     ((:cp866 . :ru) .
      #+clisp ,charset:cp866
      #+ecl :dos-cp866
      #+ccl :cannot-treat
      #+abcl :ibm866
      #+allegro :cannot-treat
-     #-(or clisp ecl ccl abcl) :cp866)
+     #+lispworks :cannot-treat
+     #-(or clisp ecl ccl abcl lispworks) :cp866)
     ((:cp1251 . :ru) .
      #+clisp ,charset:cp1251
      #+ecl :windows-cp1251
      #+ccl :cannot-treat
      #+abcl :|windows-1251|
      #+allegro :1251
-     #-(or clisp ecl ccl abcl allegro) :cp1251)
+     #+(and lispworks windows) '(win32:code-page :id 1251)
+     #-(or clisp ecl ccl abcl allegro lispworks) :cp1251)
 
     ;;; polish
     ((:iso-8859-2 . :pl) .
      #+clisp ,charset:iso-8859-2
      #+allegro :iso8859-2
-     #-(or clisp allegro) :iso-8859-2)
+     #+lispworks :cannot-treat
+     #-(or clisp allegro lispworks) :iso-8859-2)
     ((:cp1250 . :pl) .
      #+clisp ,charset:cp1250
      #+ecl :windows-cp1250
      #+ccl :cannot-treat
      #+abcl :|windows-1250|
      #+allegro :1250
-     #-(or clisp ecl ccl abcl allegro) :cp1250)
+     #+(and lispworks windows) '(win32:code-page :id 1250)
+     #-(or clisp ecl ccl abcl allegro lispworks) :cp1250)
 
     ;;; baltic
     ((:iso-8859-13 . :bl) .
      #+clisp ,charset:iso-8859-13
      #+allegro :cannot-treat
-     #-clisp :iso-8859-13)
+     #+lispworks :cannot-treat
+     #-(or clisp allegro lispworks) :iso-8859-13)
     ((:cp1257 . :bl) .
      #+clisp ,charset:cp1257
      #+ecl :windows-cp1257
      #+ccl :cannot-treat
      #+abcl :|windows-1257|
      #+allegro :1257
-     #-(or clisp ecl ccl abcl allegro) :cp1257)
+     #+(and lispworks windows) '(win32:code-page :id 1257)
+     #-(or clisp ecl ccl abcl allegro lispworks) :cp1257)
 
     ;;; end of line
     ((:lf . :eol) .
-     ;; #+lispworks :lf
      #+clisp :unix
      #+sbcl :cannot-treat
      #+ccl :unix
      #+allegro :unix
-     #-(or clisp sbcl ccl allegro) :lf)
+     #+lispworks :lf
+     #-(or clisp sbcl ccl allegro lispworks) :lf)
     ((:cr . :eol) .
-     ;; #+lispworks :cr
      #+clisp :mac
      #+sbcl :cannot-treat
      #+ccl :macos
      #+allegro :mac
-     #-(or clisp sbcl allegro) :cr)
+     #+lispworks :cr
+     #-(or clisp sbcl allegro lispworks) :cr)
     ((:crlf . :eol) .
      ;; #+lispworks :crlf
      #+clisp :dos
      #+sbcl :cannot-treat
      #+ccl :dos
      #+allegro :dos
-     #-(or clisp sbcl ccl allegro) :crlf)))
+     #+lispworks :crlf
+     #-(or clisp sbcl ccl allegro lispworks) :crlf)))
 
 (defvar +available-encodings+
   (loop

--- a/src/names.lisp
+++ b/src/names.lisp
@@ -267,10 +267,10 @@
      :collect name))
 
 (defun independent-name (dependent-name)
-  (cdr (find-if (lambda (n) (eq dependent-name (caar n))) +name-mapping+)))
+  (caar (find-if (lambda (n) (eql dependent-name (cdr n))) +name-mapping+)))
 
 (defun dependent-name (independent-name)
-  (caar (find-if (lambda (n) (eq independent-name (cdr n))) +name-mapping+)))
+  (cdr (find-if (lambda (n) (eql independent-name (caar n))) +name-mapping+)))
 
 (defun unicode-p (encoding)
   (member encoding

--- a/t/names.lisp
+++ b/t/names.lisp
@@ -171,7 +171,7 @@
       #+ccl +cannot-treat+
       #+abcl :euc-kr
       #+allegro :949
-      #+(and lispworks windows) '(win32:code-page :id 949)
+      #+(and lispworks windows) '(win32:code-page :id 949))
  (is (independent-name :johab)
       #+clisp charset:johab
       #+ecl +cannot-treat+
@@ -179,7 +179,7 @@
       #+ccl +cannot-treat+
       #+abcl :|x-Johab|
       #+allegro +cannot-treat+
-      #+lispworks +cannot-treat+))
+      #+lispworks +cannot-treat+)
  (is (independent-name :iso-2022-kr)
       #+clisp charset:iso-2022-kr
       #+ecl +cannot-treat+

--- a/t/names.lisp
+++ b/t/names.lisp
@@ -65,25 +65,29 @@
       #+ecl :utf-8
       #+sbcl :utf-8
       #+ccl :utf-8
-      #+abcl :utf-8)
+      #+abcl :utf-8
+      #+allegro :utf8)
   (is (independent-name :ucs-2le)
       #+clisp charset:unicode-16-little-endian  ;; = ucs-2 = unicode-16
       #+ecl :utf-16le  ;; = :ucs-2le
       #+sbcl :utf-16le
       #+ccl :utf-16le
-      #+abcl :utf-16le)
+      #+abcl :utf-16le
+      #+allegro +cannot-treat+)
   (is (independent-name :ucs-2be)
       #+clisp charset:unicode-16-big-endian
       #+ecl :utf-16be  ;; = :ucs-2be
       #+sbcl :utf-16be
       #+ccl :utf-16be
-      #+abcl :utf-16be)
+      #+abcl :utf-16be
+      #+allegro +cannot-treat+)
   (is (independent-name :utf-16)
       #+clisp charset:utf-16
       #+ecl :utf-16  ;; = :ucs-2
       #+sbcl +cannot-treat+
       #+ccl :utf-16
-      #+abcl :utf-16))
+      #+abcl :utf-16
+      #+allegro +cannot-treat+))
 
 (subtest "japanese"
  (is (independent-name :iso-2022-jp)
@@ -91,19 +95,22 @@
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
-      #+abcl :iso-2022-jp)
+      #+abcl :iso-2022-jp
+      #+allegro :jis)
  (is (independent-name :euc-jp)
       #+clisp charset:euc-jp
       #+ecl +cannot-treat+
       #+sbcl :euc-jp
       #+ccl :euc-jp
-      #+abcl :euc-jp)
+      #+abcl :euc-jp
+      #+allegro :euc)  ; I tried.
  (is (independent-name :cp932)
       #+clisp charset:cp932
       #+ecl :windows-cp932
       #+sbcl :shift_jis
       #+ccl :windows-31j
-      #+abcl :|x-MS932_0213|))
+      #+abcl :|x-MS932_0213|
+      #+allegro :shiftjis))
 
 (subtest "tiwanese"
  (is (independent-name :big5)
@@ -111,13 +118,15 @@
       #+ecl :windows-cp950
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
-      #+abcl :|Big5|)
+      #+abcl :|Big5|
+      #+allegro :big5)
  (is (independent-name :iso-2022-tw)
       #+clisp charset:euc-tw
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
-      #+abcl :|x-EUC-TW|))
+      #+abcl :|x-EUC-TW|
+      #+allegro +cannot-treat+))
 
 (subtest "chinese"
  (is (independent-name :gb2312)  ;; = EUC-CN, GBK, cp936
@@ -125,19 +134,22 @@
       #+ecl :windows-cp936
       #+sbcl :gbk
       #+ccl :cp936
-      #+abcl :gbk)
+      #+abcl :gbk
+      #+allegro +cannot-treat+)
  (is (independent-name :gb18030)
       #+clisp charset:gb18030
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
-      #+abcl :gb18030)
+      #+abcl :gb18030
+      #+allegro :gb18030)
  (is (independent-name :iso-2022-cn)
       #+clisp charset:iso-2022-cn
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
-      #+abcl :iso-2022-cn))
+      #+abcl :iso-2022-cn
+      #+allegro +cannot-treat+))
 
 (subtest "korean"
  (is (independent-name :euc-kr)
@@ -145,19 +157,22 @@
       #+ecl :windows-cp949
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
-      #+abcl :euc-kr)
+      #+abcl :euc-kr
+      #+allegro :949)
  (is (independent-name :johab)
       #+clisp charset:johab
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
-      #+abcl :|x-Johab|)
+      #+abcl :|x-Johab|
+      #+allegro +cannot-treat+)
  (is (independent-name :iso-2022-kr)
       #+clisp charset:iso-2022-kr
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
-      #+abcl :iso-2022-kr))
+      #+abcl :iso-2022-kr
+      #+allegro +cannot-treat+))
 
 (subtest "arabic"
  (is (independent-name :iso-8859-6)
@@ -165,13 +180,15 @@
       #+ecl :iso-8859-6
       #+sbcl :iso-8859-6
       #+ccl :iso-8859-6
-      #+abcl :iso-8859-6)
+      #+abcl :iso-8859-6
+      #+allegro iso8859-6)
  (is (independent-name :cp1256)
       #+clisp charset:windows-1256
       #+ecl :windows-cp1256
       #+sbcl :cp1256
       #+ccl +cannot-treat+
-      #+abcl :|windows-1256|))
+      #+abcl :|windows-1256|
+      #+allegro :1256))
 
 (subtest "greek"
  (is (independent-name :iso-8859-7)
@@ -179,13 +196,15 @@
       #+ecl :iso-8859-7
       #+sbcl :iso-8859-7
       #+ccl :iso-8859-7
-      #+abcl :iso-8859-7)
+      #+abcl :iso-8859-7
+      #+allegro :iso8859-7)
  (is (independent-name :cp1253)
       #+clisp charset:windows-1253
       #+ecl :windows-cp1253
       #+sbcl :cp1253
       #+ccl +cannot-treat+
-      #+abcl :|windows-1253|))
+      #+abcl :|windows-1253|
+      #+allegro :1253))
 
 (subtest "hebrew"
   (is (independent-name :iso-8859-8)
@@ -193,13 +212,15 @@
       #+ecl :iso-8859-8
       #+sbcl :iso-8859-8
       #+ccl :iso-8859-8
-      #+abcl :iso-8859-8)
+      #+abcl :iso-8859-8
+      #+allegro :iso8859-8)
   (is (independent-name :cp1255)
       #+clisp charset:windows-1255
       #+ecl :windows-cp1255
       #+sbcl :cp1255
       #+ccl +cannot-treat+
-      #+abcl :|windows-1255|))
+      #+abcl :|windows-1255|
+      #+allegro :1255))
 
 (subtest "turkish"
   (is (independent-name :iso-8859-9)
@@ -207,13 +228,15 @@
       #+ecl :iso-8859-9
       #+sbcl :iso-8859-9
       #+ccl :iso-8859-9
-      #+abcl :iso-8859-9)
+      #+abcl :iso-8859-9
+      #+allegro :iso8859-9)
   (is (independent-name :cp1254)
       #+clisp charset:windows-1254
       #+ecl :windows-cp1254
       #+sbcl :cp1254
       #+ccl +cannot-treat+
-      #+abcl :|windows-1254|))
+      #+abcl :|windows-1254|
+      #+allegro :1254))
 
 (subtest "russian"
   (is (independent-name :iso-8859-5)
@@ -221,31 +244,36 @@
       #+ecl :iso-8859-5
       #+sbcl :iso-8859-5
       #+ccl :iso-8859-5
-      #+abcl :iso-8859-5)
+      #+abcl :iso-8859-5
+      #+allegro :iso8859-5)
   (is (independent-name :koi8-r)
       #+clisp charset:koi8-r
       #+ecl +cannot-treat+
       #+sbcl :koi8-r
       #+ccl +cannot-treat+
-      #+abcl :koi8-r)
+      #+abcl :koi8-r
+      #+allegro :koi8-r)
   (is (independent-name :koi8-u)
       #+clisp charset:koi8-u
       #+ecl +cannot-treat+
       #+sbcl :koi8-u
       #+ccl +cannot-treat+
-      #+abcl :koi8-u)
+      #+abcl :koi8-u
+      #+allegro +cannot-treat+)
   (is (independent-name :cp866)
       #+clisp charset:cp866
       #+ecl :dos-cp866
       #+sbcl :cp866
       #+ccl +cannot-treat+
-      #+abcl :ibm866)
+      #+abcl :ibm866
+      #+allegro +cannot-treat+)
   (is (independent-name :cp1251)
       #+clisp charset:windows-1251
       #+ecl :windows-cp1251
       #+sbcl :cp1251
       #+ccl +cannot-treat+
-      #+abcl :|windows-1251|))
+      #+abcl :|windows-1251|
+      #+allegro :1251))
 
 (subtest "polish"
   (is (independent-name :iso-8859-2)
@@ -253,13 +281,15 @@
       #+ecl :iso-8859-2
       #+sbcl :iso-8859-2
       #+ccl :iso-8859-2
-      #+abcl :iso-8859-2)
+      #+abcl :iso-8859-2
+      #+allegro :iso8859-2)
   (is (independent-name :cp1250)
       #+clisp charset:windows-1250
       #+ecl :windows-cp1250
       #+sbcl :cp1250
       #+ccl +cannot-treat+
-      #+abcl :|windows-1250|))
+      #+abcl :|windows-1250|
+      #+allegro :1250))
 
 (subtest "baltic"
   (is (independent-name :iso-8859-13)
@@ -267,13 +297,15 @@
       #+ecl :iso-8859-13
       #+sbcl :iso-8859-13
       #+ccl :iso-8859-13
-      #+abcl :iso-8859-13)
+      #+abcl :iso-8859-13
+      #+allegro +cannot-treat+)
   (is (independent-name :cp1257)
       #+clisp charset:windows-1257
       #+ecl :windows-cp1257
       #+sbcl :cp1257
       #+ccl +cannot-treat+
-      #+abcl :|windows-1257|))
+      #+abcl :|windows-1257|
+      #+allegro :1257))
 
 (subtest "end of line"
   (is (independent-name :lf)
@@ -281,19 +313,22 @@
       #+ecl :lf
       #+sbcl +cannot-treat+
       #+ccl :unix
-      #+abcl :lf)
+      #+abcl :lf
+      #+allegro :unix)  ; https://franz.com/support/documentation/10.1/doc/operators/excl/eol-convention.htm
   (is (independent-name :cr)
       #+clisp :mac
       #+ecl :cr
       #+sbcl +cannot-treat+
       #+ccl :macos
-      #+abcl :cr)
+      #+abcl :cr
+      #+allegro :mac)
   (is (independent-name :crlf)
       #+clisp :dos
       #+ecl :crlf
       #+sbcl +cannot-treat+
       #+ccl :dos
-      #+abcl :crlf))
+      #+abcl :crlf
+      #+allegro :doc))
 
 (subtest "if specified encodings is unicode?"
   (subtest "only unicode returns t"

--- a/t/names.lisp
+++ b/t/names.lisp
@@ -60,7 +60,7 @@
 (defvar +cannot-treat+ :cannot-treat)
 
 (subtest "unicode"
-  (is (independent-name :utf-8)
+  (is (dependent-name :utf-8)
       #+clisp charset:utf-8
       #+ecl :utf-8
       #+sbcl :utf-8
@@ -68,7 +68,7 @@
       #+abcl :utf-8
       #+allegro :utf8
       #+lispworks :utf-8)
-  (is (independent-name :ucs-2le)
+  (is (dependent-name :ucs-2le)
       #+clisp charset:unicode-16-little-endian  ;; = ucs-2 = unicode-16
       #+ecl :utf-16le  ;; = :ucs-2le
       #+sbcl :utf-16le
@@ -76,7 +76,7 @@
       #+abcl :utf-16le
       #+allegro +cannot-treat+
       #+lispworks '(:unicode :little-endian))
-  (is (independent-name :ucs-2be)
+  (is (dependent-name :ucs-2be)
       #+clisp charset:unicode-16-big-endian
       #+ecl :utf-16be  ;; = :ucs-2be
       #+sbcl :utf-16be
@@ -84,7 +84,7 @@
       #+abcl :utf-16be
       #+allegro +cannot-treat+
       #+lispworks '(:unicode :big-endian))
-  (is (independent-name :utf-16)
+  (is (dependent-name :utf-16)
       #+clisp charset:utf-16
       #+ecl :utf-16  ;; = :ucs-2
       #+sbcl +cannot-treat+
@@ -94,7 +94,7 @@
       #+lispworks +cannot-treat+))
 
 (subtest "japanese"
- (is (independent-name :iso-2022-jp)
+ (is (dependent-name :iso-2022-jp)
       #+clisp charset:iso-2022-jp
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
@@ -102,7 +102,7 @@
       #+abcl :iso-2022-jp
       #+allegro :jis
       #+lispworks :jis)
- (is (independent-name :euc-jp)
+ (is (dependent-name :euc-jp)
       #+clisp charset:euc-jp
       #+ecl +cannot-treat+
       #+sbcl :euc-jp
@@ -110,7 +110,7 @@
       #+abcl :euc-jp
       #+allegro :euc  ; I tried.
       #+lispworks :euc-jp)
- (is (independent-name :cp932)
+ (is (dependent-name :cp932)
       #+clisp charset:cp932
       #+ecl :windows-cp932
       #+sbcl :shift_jis
@@ -120,7 +120,7 @@
       #+lispworks :sjis))
 
 (subtest "tiwanese"
- (is (independent-name :big5)
+ (is (dependent-name :big5)
       #+clisp charset:big5
       #+ecl :windows-cp950
       #+sbcl +cannot-treat+
@@ -128,7 +128,7 @@
       #+abcl :|Big5|
       #+allegro :big5
       #+(and lispworks windows) '(win32:code-page :id 950))
- (is (independent-name :iso-2022-tw)
+ (is (dependent-name :iso-2022-tw)
       #+clisp charset:euc-tw
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
@@ -138,7 +138,7 @@
       #+lispworks +cannot-treat+))
 
 (subtest "chinese"
- (is (independent-name :gb2312)  ;; = EUC-CN, GBK, cp936
+ (is (dependent-name :gb2312)  ;; = EUC-CN, GBK, cp936
       #+clisp charset:gbk
       #+ecl :windows-cp936
       #+sbcl :gbk
@@ -146,7 +146,7 @@
       #+abcl :gbk
       #+allegro +cannot-treat+
       #+lispworks :gbk)
- (is (independent-name :gb18030)
+ (is (dependent-name :gb18030)
       #+clisp charset:gb18030
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
@@ -154,7 +154,7 @@
       #+abcl :gb18030
       #+allegro :gb18030
       #+lispworks +cannot-treat+)
- (is (independent-name :iso-2022-cn)
+ (is (dependent-name :iso-2022-cn)
       #+clisp charset:iso-2022-cn
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
@@ -164,7 +164,7 @@
       #+lispworks +cannot-treat+))
 
 (subtest "korean"
- (is (independent-name :euc-kr)
+ (is (dependent-name :euc-kr)
       #+clisp charset:euc-kr
       #+ecl :windows-cp949
       #+sbcl +cannot-treat+
@@ -172,7 +172,7 @@
       #+abcl :euc-kr
       #+allegro :949
       #+(and lispworks windows) '(win32:code-page :id 949))
- (is (independent-name :johab)
+ (is (dependent-name :johab)
       #+clisp charset:johab
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
@@ -180,7 +180,7 @@
       #+abcl :|x-Johab|
       #+allegro +cannot-treat+
       #+lispworks +cannot-treat+)
- (is (independent-name :iso-2022-kr)
+ (is (dependent-name :iso-2022-kr)
       #+clisp charset:iso-2022-kr
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
@@ -190,7 +190,7 @@
       #+lispworks +cannot-treat+))
 
 (subtest "arabic"
- (is (independent-name :iso-8859-6)
+ (is (dependent-name :iso-8859-6)
       #+clisp charset:iso-8859-6
       #+ecl :iso-8859-6
       #+sbcl :iso-8859-6
@@ -198,7 +198,7 @@
       #+abcl :iso-8859-6
       #+allegro iso8859-6
       #+lispworks +cannot-treat+)
- (is (independent-name :cp1256)
+ (is (dependent-name :cp1256)
       #+clisp charset:windows-1256
       #+ecl :windows-cp1256
       #+sbcl :cp1256
@@ -208,7 +208,7 @@
       #+(and lispworks windows) '(win32:code-page :id 1256)))
 
 (subtest "greek"
- (is (independent-name :iso-8859-7)
+ (is (dependent-name :iso-8859-7)
       #+clisp charset:iso-8859-7
       #+ecl :iso-8859-7
       #+sbcl :iso-8859-7
@@ -216,7 +216,7 @@
       #+abcl :iso-8859-7
       #+allegro :iso8859-7
       #+lispworks +cannot-treat+)
- (is (independent-name :cp1253)
+ (is (dependent-name :cp1253)
       #+clisp charset:windows-1253
       #+ecl :windows-cp1253
       #+sbcl :cp1253
@@ -226,7 +226,7 @@
       #+(and lispworks windows) '(win32:code-page :id 1253)))
 
 (subtest "hebrew"
-  (is (independent-name :iso-8859-8)
+  (is (dependent-name :iso-8859-8)
       #+clisp charset:iso-8859-8
       #+ecl :iso-8859-8
       #+sbcl :iso-8859-8
@@ -234,7 +234,7 @@
       #+abcl :iso-8859-8
       #+allegro :iso8859-8
       #+lispworks +cannot-treat+)
-  (is (independent-name :cp1255)
+  (is (dependent-name :cp1255)
       #+clisp charset:windows-1255
       #+ecl :windows-cp1255
       #+sbcl :cp1255
@@ -244,7 +244,7 @@
       #+(and lispworks windows) '(win32:code-page :id 1255)))
 
 (subtest "turkish"
-  (is (independent-name :iso-8859-9)
+  (is (dependent-name :iso-8859-9)
       #+clisp charset:iso-8859-9
       #+ecl :iso-8859-9
       #+sbcl :iso-8859-9
@@ -252,7 +252,7 @@
       #+abcl :iso-8859-9
       #+allegro :iso8859-9
       #+lispworks +cannot-treat+)
-  (is (independent-name :cp1254)
+  (is (dependent-name :cp1254)
       #+clisp charset:windows-1254
       #+ecl :windows-cp1254
       #+sbcl :cp1254
@@ -262,7 +262,7 @@
       #+(and lispworks windows) '(win32:code-page :id 1254)))
 
 (subtest "russian"
-  (is (independent-name :iso-8859-5)
+  (is (dependent-name :iso-8859-5)
       #+clisp charset:iso-8859-5
       #+ecl :iso-8859-5
       #+sbcl :iso-8859-5
@@ -270,7 +270,7 @@
       #+abcl :iso-8859-5
       #+allegro :iso8859-5
       #+lispworks +cannot-treat+)
-  (is (independent-name :koi8-r)
+  (is (dependent-name :koi8-r)
       #+clisp charset:koi8-r
       #+ecl +cannot-treat+
       #+sbcl :koi8-r
@@ -278,7 +278,7 @@
       #+abcl :koi8-r
       #+allegro :koi8-r
       #+lispworks +cannot-treat+)
-  (is (independent-name :koi8-u)
+  (is (dependent-name :koi8-u)
       #+clisp charset:koi8-u
       #+ecl +cannot-treat+
       #+sbcl :koi8-u
@@ -286,7 +286,7 @@
       #+abcl :koi8-u
       #+allegro +cannot-treat+
       #+lispworks +cannot-treat+)
-  (is (independent-name :cp866)
+  (is (dependent-name :cp866)
       #+clisp charset:cp866
       #+ecl :dos-cp866
       #+sbcl :cp866
@@ -294,7 +294,7 @@
       #+abcl :ibm866
       #+allegro +cannot-treat+
       #+lispworks +cannot-treat+)
-  (is (independent-name :cp1251)
+  (is (dependent-name :cp1251)
       #+clisp charset:windows-1251
       #+ecl :windows-cp1251
       #+sbcl :cp1251
@@ -304,7 +304,7 @@
       #+(and lispworks windows) '(win32:code-page :id 1251)))
 
 (subtest "polish"
-  (is (independent-name :iso-8859-2)
+  (is (dependent-name :iso-8859-2)
       #+clisp charset:iso-8859-2
       #+ecl :iso-8859-2
       #+sbcl :iso-8859-2
@@ -312,7 +312,7 @@
       #+abcl :iso-8859-2
       #+allegro :iso8859-2
       #+lispworks +cannot-treat+)
-  (is (independent-name :cp1250)
+  (is (dependent-name :cp1250)
       #+clisp charset:windows-1250
       #+ecl :windows-cp1250
       #+sbcl :cp1250
@@ -322,7 +322,7 @@
       #+(and lispworks windows) '(win32:code-page :id 1250)))
 
 (subtest "baltic"
-  (is (independent-name :iso-8859-13)
+  (is (dependent-name :iso-8859-13)
       #+clisp charset:iso-8859-13
       #+ecl :iso-8859-13
       #+sbcl :iso-8859-13
@@ -330,7 +330,7 @@
       #+abcl :iso-8859-13
       #+allegro +cannot-treat+
       #+lispworks +cannot-treat+)
-  (is (independent-name :cp1257)
+  (is (dependent-name :cp1257)
       #+clisp charset:windows-1257
       #+ecl :windows-cp1257
       #+sbcl :cp1257
@@ -340,7 +340,7 @@
       #+(and lispworks windows) '(win32:code-page :id 1257)))
 
 (subtest "end of line"
-  (is (independent-name :lf)
+  (is (dependent-name :lf)
       #+clisp :unix
       #+ecl :lf
       #+sbcl +cannot-treat+
@@ -348,7 +348,7 @@
       #+abcl :lf
       #+allegro :unix  ; https://franz.com/support/documentation/10.1/doc/operators/excl/eol-convention.htm
       #+lispworks :lf)
-  (is (independent-name :cr)
+  (is (dependent-name :cr)
       #+clisp :mac
       #+ecl :cr
       #+sbcl +cannot-treat+
@@ -356,7 +356,7 @@
       #+abcl :cr
       #+allegro :mac
       #+lispworks :cr)
-  (is (independent-name :crlf)
+  (is (dependent-name :crlf)
       #+clisp :dos
       #+ecl :crlf
       #+sbcl +cannot-treat+

--- a/t/names.lisp
+++ b/t/names.lisp
@@ -66,28 +66,32 @@
       #+sbcl :utf-8
       #+ccl :utf-8
       #+abcl :utf-8
-      #+allegro :utf8)
+      #+allegro :utf8
+      #+lispworks :utf-8)
   (is (independent-name :ucs-2le)
       #+clisp charset:unicode-16-little-endian  ;; = ucs-2 = unicode-16
       #+ecl :utf-16le  ;; = :ucs-2le
       #+sbcl :utf-16le
       #+ccl :utf-16le
       #+abcl :utf-16le
-      #+allegro +cannot-treat+)
+      #+allegro +cannot-treat+
+      #+lispworks '(:unicode :little-endian))
   (is (independent-name :ucs-2be)
       #+clisp charset:unicode-16-big-endian
       #+ecl :utf-16be  ;; = :ucs-2be
       #+sbcl :utf-16be
       #+ccl :utf-16be
       #+abcl :utf-16be
-      #+allegro +cannot-treat+)
+      #+allegro +cannot-treat+
+      #+lispworks '(:unicode :big-endian))
   (is (independent-name :utf-16)
       #+clisp charset:utf-16
       #+ecl :utf-16  ;; = :ucs-2
       #+sbcl +cannot-treat+
       #+ccl :utf-16
       #+abcl :utf-16
-      #+allegro +cannot-treat+))
+      #+allegro +cannot-treat+
+      #+lispworks +cannot-treat+))
 
 (subtest "japanese"
  (is (independent-name :iso-2022-jp)
@@ -96,21 +100,24 @@
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
       #+abcl :iso-2022-jp
-      #+allegro :jis)
+      #+allegro :jis
+      #+lispworks :jis)
  (is (independent-name :euc-jp)
       #+clisp charset:euc-jp
       #+ecl +cannot-treat+
       #+sbcl :euc-jp
       #+ccl :euc-jp
       #+abcl :euc-jp
-      #+allegro :euc)  ; I tried.
+      #+allegro :euc  ; I tried.
+      #+lispworks :euc-jp)
  (is (independent-name :cp932)
       #+clisp charset:cp932
       #+ecl :windows-cp932
       #+sbcl :shift_jis
       #+ccl :windows-31j
       #+abcl :|x-MS932_0213|
-      #+allegro :shiftjis))
+      #+allegro :shiftjis
+      #+lispworks :sjis))
 
 (subtest "tiwanese"
  (is (independent-name :big5)
@@ -119,14 +126,16 @@
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
       #+abcl :|Big5|
-      #+allegro :big5)
+      #+allegro :big5
+      #+(and lispworks windows) '(win32:code-page :id 950))
  (is (independent-name :iso-2022-tw)
       #+clisp charset:euc-tw
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
       #+abcl :|x-EUC-TW|
-      #+allegro +cannot-treat+))
+      #+allegro +cannot-treat+
+      #+lispworks +cannot-treat+))
 
 (subtest "chinese"
  (is (independent-name :gb2312)  ;; = EUC-CN, GBK, cp936
@@ -135,21 +144,24 @@
       #+sbcl :gbk
       #+ccl :cp936
       #+abcl :gbk
-      #+allegro +cannot-treat+)
+      #+allegro +cannot-treat+
+      #+lispworks :gbk)
  (is (independent-name :gb18030)
       #+clisp charset:gb18030
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
       #+abcl :gb18030
-      #+allegro :gb18030)
+      #+allegro :gb18030
+      #+lispworks +cannot-treat+)
  (is (independent-name :iso-2022-cn)
       #+clisp charset:iso-2022-cn
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
       #+abcl :iso-2022-cn
-      #+allegro +cannot-treat+))
+      #+allegro +cannot-treat+
+      #+lispworks +cannot-treat+))
 
 (subtest "korean"
  (is (independent-name :euc-kr)
@@ -158,21 +170,24 @@
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
       #+abcl :euc-kr
-      #+allegro :949)
+      #+allegro :949
+      #+(and lispworks windows) '(win32:code-page :id 949)
  (is (independent-name :johab)
       #+clisp charset:johab
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
       #+abcl :|x-Johab|
-      #+allegro +cannot-treat+)
+      #+allegro +cannot-treat+
+      #+lispworks +cannot-treat+))
  (is (independent-name :iso-2022-kr)
       #+clisp charset:iso-2022-kr
       #+ecl +cannot-treat+
       #+sbcl +cannot-treat+
       #+ccl +cannot-treat+
       #+abcl :iso-2022-kr
-      #+allegro +cannot-treat+))
+      #+allegro +cannot-treat+
+      #+lispworks +cannot-treat+))
 
 (subtest "arabic"
  (is (independent-name :iso-8859-6)
@@ -181,14 +196,16 @@
       #+sbcl :iso-8859-6
       #+ccl :iso-8859-6
       #+abcl :iso-8859-6
-      #+allegro iso8859-6)
+      #+allegro iso8859-6
+      #+lispworks +cannot-treat+)
  (is (independent-name :cp1256)
       #+clisp charset:windows-1256
       #+ecl :windows-cp1256
       #+sbcl :cp1256
       #+ccl +cannot-treat+
       #+abcl :|windows-1256|
-      #+allegro :1256))
+      #+allegro :1256
+      #+(and lispworks windows) '(win32:code-page :id 1256)))
 
 (subtest "greek"
  (is (independent-name :iso-8859-7)
@@ -197,14 +214,16 @@
       #+sbcl :iso-8859-7
       #+ccl :iso-8859-7
       #+abcl :iso-8859-7
-      #+allegro :iso8859-7)
+      #+allegro :iso8859-7
+      #+lispworks +cannot-treat+)
  (is (independent-name :cp1253)
       #+clisp charset:windows-1253
       #+ecl :windows-cp1253
       #+sbcl :cp1253
       #+ccl +cannot-treat+
       #+abcl :|windows-1253|
-      #+allegro :1253))
+      #+allegro :1253
+      #+(and lispworks windows) '(win32:code-page :id 1253)))
 
 (subtest "hebrew"
   (is (independent-name :iso-8859-8)
@@ -213,14 +232,16 @@
       #+sbcl :iso-8859-8
       #+ccl :iso-8859-8
       #+abcl :iso-8859-8
-      #+allegro :iso8859-8)
+      #+allegro :iso8859-8
+      #+lispworks +cannot-treat+)
   (is (independent-name :cp1255)
       #+clisp charset:windows-1255
       #+ecl :windows-cp1255
       #+sbcl :cp1255
       #+ccl +cannot-treat+
       #+abcl :|windows-1255|
-      #+allegro :1255))
+      #+allegro :1255
+      #+(and lispworks windows) '(win32:code-page :id 1255)))
 
 (subtest "turkish"
   (is (independent-name :iso-8859-9)
@@ -229,14 +250,16 @@
       #+sbcl :iso-8859-9
       #+ccl :iso-8859-9
       #+abcl :iso-8859-9
-      #+allegro :iso8859-9)
+      #+allegro :iso8859-9
+      #+lispworks +cannot-treat+)
   (is (independent-name :cp1254)
       #+clisp charset:windows-1254
       #+ecl :windows-cp1254
       #+sbcl :cp1254
       #+ccl +cannot-treat+
       #+abcl :|windows-1254|
-      #+allegro :1254))
+      #+allegro :1254
+      #+(and lispworks windows) '(win32:code-page :id 1254)))
 
 (subtest "russian"
   (is (independent-name :iso-8859-5)
@@ -245,35 +268,40 @@
       #+sbcl :iso-8859-5
       #+ccl :iso-8859-5
       #+abcl :iso-8859-5
-      #+allegro :iso8859-5)
+      #+allegro :iso8859-5
+      #+lispworks +cannot-treat+)
   (is (independent-name :koi8-r)
       #+clisp charset:koi8-r
       #+ecl +cannot-treat+
       #+sbcl :koi8-r
       #+ccl +cannot-treat+
       #+abcl :koi8-r
-      #+allegro :koi8-r)
+      #+allegro :koi8-r
+      #+lispworks +cannot-treat+)
   (is (independent-name :koi8-u)
       #+clisp charset:koi8-u
       #+ecl +cannot-treat+
       #+sbcl :koi8-u
       #+ccl +cannot-treat+
       #+abcl :koi8-u
-      #+allegro +cannot-treat+)
+      #+allegro +cannot-treat+
+      #+lispworks +cannot-treat+)
   (is (independent-name :cp866)
       #+clisp charset:cp866
       #+ecl :dos-cp866
       #+sbcl :cp866
       #+ccl +cannot-treat+
       #+abcl :ibm866
-      #+allegro +cannot-treat+)
+      #+allegro +cannot-treat+
+      #+lispworks +cannot-treat+)
   (is (independent-name :cp1251)
       #+clisp charset:windows-1251
       #+ecl :windows-cp1251
       #+sbcl :cp1251
       #+ccl +cannot-treat+
       #+abcl :|windows-1251|
-      #+allegro :1251))
+      #+allegro :1251
+      #+(and lispworks windows) '(win32:code-page :id 1251)))
 
 (subtest "polish"
   (is (independent-name :iso-8859-2)
@@ -282,14 +310,16 @@
       #+sbcl :iso-8859-2
       #+ccl :iso-8859-2
       #+abcl :iso-8859-2
-      #+allegro :iso8859-2)
+      #+allegro :iso8859-2
+      #+lispworks +cannot-treat+)
   (is (independent-name :cp1250)
       #+clisp charset:windows-1250
       #+ecl :windows-cp1250
       #+sbcl :cp1250
       #+ccl +cannot-treat+
       #+abcl :|windows-1250|
-      #+allegro :1250))
+      #+allegro :1250
+      #+(and lispworks windows) '(win32:code-page :id 1250)))
 
 (subtest "baltic"
   (is (independent-name :iso-8859-13)
@@ -298,14 +328,16 @@
       #+sbcl :iso-8859-13
       #+ccl :iso-8859-13
       #+abcl :iso-8859-13
-      #+allegro +cannot-treat+)
+      #+allegro +cannot-treat+
+      #+lispworks +cannot-treat+)
   (is (independent-name :cp1257)
       #+clisp charset:windows-1257
       #+ecl :windows-cp1257
       #+sbcl :cp1257
       #+ccl +cannot-treat+
       #+abcl :|windows-1257|
-      #+allegro :1257))
+      #+allegro :1257
+      #+(and lispworks windows) '(win32:code-page :id 1257)))
 
 (subtest "end of line"
   (is (independent-name :lf)
@@ -314,21 +346,24 @@
       #+sbcl +cannot-treat+
       #+ccl :unix
       #+abcl :lf
-      #+allegro :unix)  ; https://franz.com/support/documentation/10.1/doc/operators/excl/eol-convention.htm
+      #+allegro :unix  ; https://franz.com/support/documentation/10.1/doc/operators/excl/eol-convention.htm
+      #+lispworks :lf)
   (is (independent-name :cr)
       #+clisp :mac
       #+ecl :cr
       #+sbcl +cannot-treat+
       #+ccl :macos
       #+abcl :cr
-      #+allegro :mac)
+      #+allegro :mac
+      #+lispworks :cr)
   (is (independent-name :crlf)
       #+clisp :dos
       #+ecl :crlf
       #+sbcl +cannot-treat+
       #+ccl :dos
       #+abcl :crlf
-      #+allegro :doc))
+      #+allegro :doc
+      #+lispworks :crlf))
 
 (subtest "if specified encodings is unicode?"
   (subtest "only unicode returns t"


### PR DESCRIPTION
`dependent-name` / `independent-name` supports external-formats defined in Allegro CL and LispWorks.

And, fixes a bug such that:
- `dependent-name` returns independent name, it's NOT dependent name
- `independent-name` returns dependent name, it's NOT independent name