### PR TITLE
i21 flexi-streams support

### DIFF
--- a/inquisitor-flex-test.asd
+++ b/inquisitor-flex-test.asd
@@ -1,0 +1,18 @@
+(in-package :cl-user)
+(defpackage inquisitor-flex-test-asd
+  (:use :cl :asdf))
+(in-package :inquisitor-flex-test-asd)
+
+(defsystem inquisitor-flex-test
+  :author "Shinichi TANAKA"
+  :license "MIT"
+  :depends-on (:inquisitor-flex)
+  :components ((:module "t"
+                :components
+                ((:module "ext"
+                  :components
+                  ((:file "flexi-streams"))))))
+  :defsystem-depends-on (:prove-asdf)
+  :perform (test-op :after (op c)
+                    (funcall (intern #.(string :run-test-system) :prove-asdf) c)
+                    (asdf:clear-system c)))

--- a/inquisitor-flex.asd
+++ b/inquisitor-flex.asd
@@ -1,0 +1,18 @@
+(in-package :cl-user)
+(defpackage inquisitor-flex-asd
+  (:use :cl :asdf))
+(in-package :inquisitor-flex-asd)
+
+(defsystem inquisitor-flex
+  :version "0.1"
+  :description "Inquisitor with flexi-streams support"
+  :author "Shinichi TANAKA"
+  :license "MIT"
+  :depends-on (:flexi-streams
+               :inquisitor)
+  :components ((:module "src"
+                :components
+                ((:module "ext"
+                  :components
+                  ((:file "flexi-streams"))))))
+  :in-order-to ((test-op (test-op inquisitor-flex-test))))

--- a/inquisitor-test.asd
+++ b/inquisitor-test.asd
@@ -13,6 +13,7 @@
   :license "MIT"
   :depends-on (:inquisitor
                :babel
+               :flexi-streams
                :prove)
   :components ((:module "t"
                 :components

--- a/src/ext/flexi-streams.lisp
+++ b/src/ext/flexi-streams.lisp
@@ -1,0 +1,87 @@
+(in-package :cl-user)
+(defpackage :inquisitor.ext.flexi-steams
+  (:use :cl)
+  (:import-from :inquisitor
+                :dependent-name
+                :make-external-format))
+(in-package :inquisitor.ext.flexi-steams)
+
+(flet ((name-pos (independent-name)
+         (position independent-name
+                   inquisitor.names::+name-mapping+
+                   :key (lambda (enc) (getf enc :name))))
+       (add-new-value (pos key value)
+         (setf (nth pos inquisitor.names::+name-mapping+)
+               (append (nth pos inquisitor.names::+name-mapping+)
+                       (list key value)))))
+  ;; Unicode
+  (add-new-value (name-pos :utf-8) :flexi-name :utf-8)
+  (add-new-value (name-pos :ucs-2le) :flexi-name nil)
+  (add-new-value (name-pos :ucs-2be) :flexi-name nil)
+  (add-new-value (name-pos :utf-16) :flexi-name :utf-16)
+
+  ;; Japanese
+  (add-new-value (name-pos :iso-2022-jp) :flexi-name nil)
+  (add-new-value (name-pos :euc-jp) :flexi-name nil)
+  (add-new-value (name-pos :cp932) :flexi-name nil)
+
+  ;; Taiwanese
+  (add-new-value (name-pos :big5) :flexi-name nil)
+  (add-new-value (name-pos :iso-2022-tw) :flexi-name nil)
+
+  ;; Chinese
+  (add-new-value (name-pos :gb2312) :flexi-name nil)
+  (add-new-value (name-pos :gb18030) :flexi-name nil)
+  (add-new-value (name-pos :iso-2022-cn) :flexi-name nil)
+
+  ;; Korean
+  (add-new-value (name-pos :euc-kr) :flexi-name nil)
+  (add-new-value (name-pos :johab) :flexi-name nil)
+  (add-new-value (name-pos :iso-2022-kr) :flexi-name nil)
+
+  ;; Arabic
+  (add-new-value (name-pos :iso-8859-6) :flexi-name :iso-8859-6)
+  (add-new-value (name-pos ::cp1256) :flexi-name nil)
+
+  ;; Greek
+  (add-new-value (name-pos :iso-8859-7) :flexi-name :iso-8859-7)
+  (add-new-value (name-pos :cp1253) :flexi-name nil)
+
+  ;; Hebrew
+  (add-new-value (name-pos :iso-8859-8) :flexi-name :iso-8859-8)
+  (add-new-value (name-pos :cp1255) :flexi-name nil)
+
+  ;; Turkish
+  (add-new-value (name-pos :iso-8859-9) :flexi-name :iso-8859-9)
+  (add-new-value (name-pos :cp1254) :flexi-name nil)
+
+  ;; Russian
+  (add-new-value (name-pos :iso-8859-5) :flexi-name :iso-8859-5)
+  (add-new-value (name-pos :koi8-r) :flexi-name :koi8-r)
+  (add-new-value (name-pos :koi8-u) :flexi-name nil)
+  (add-new-value (name-pos :cp866) :flexi-name nil)
+  (add-new-value (name-pos :cp1251) :flexi-name nil)
+
+  ;; Polish
+  (add-new-value (name-pos :iso-8859-2) :flexi-name :iso-8859-2)
+  (add-new-value (name-pos :cp1250) :flexi-name nil)
+
+  ;; Baltic
+  (add-new-value (name-pos :iso-8859-13) :flexi-name :iso-8859-13)
+  (add-new-value (name-pos :cp1257) :flexi-name nil)
+
+  ;; End of line markers
+  (add-new-value (name-pos :lf) :flexi-name :lf)
+  (add-new-value (name-pos :cr) :flexi-name :cr)
+  (add-new-value (name-pos :crlf) :flexi-name :crlf))
+
+(defmethod make-external-format
+    ((type (eql :flexi)) enc eol &rest args &key &allow-other-keys)
+  (let* ((enc-flexi (dependent-name enc :flexi))
+         (eol-flexi (dependent-name eol :flexi))
+         (args (append (list enc :eol-style eol)
+                       (loop
+                          :for (k v) :on args :by #'cddr
+                          :unless (eq k :type)
+                          :nconc (list k v)))))
+    (apply #'flexi-streams:make-external-format args)))

--- a/src/external-format.lisp
+++ b/src/external-format.lisp
@@ -3,20 +3,32 @@
   (:use :cl)
   (:export :make-external-format)
   (:import-from :inquisitor.names
+                :dependent-name
                 :independent-name))
 (in-package :inquisitor.external-format)
 
 
-(defun make-external-format (enc eol)
-  (let ((enc-on-impl (independent-name enc))
-        (eol-on-impl (independent-name eol)))
-    (declare (ignorable eol-on-impl))
-    #+clisp (ext:make-encoding :charset enc-on-impl
-                               :line-terminator eol-on-impl)
-    #+ecl `(,enc-on-impl ,eol-on-impl)
-    #+sbcl enc-on-impl
-    #+ccl (ccl:make-external-format :character-encoding enc-on-impl
-                                    :line-termination eol-on-impl)
-    #+abcl `(,enc-on-impl :eol-style ,eol-on-impl)
-    #-(or clisp ecl sbcl ccl abcl)
-    (error "your implementation is not supported.")))
+(defun make-external-format (enc eol &rest args &key (type :impl) &allow-other-keys)
+  (ecase type
+    (:flexi (let* ((enc-flexi (dependent-name enc :flexi))
+                   (eol-flexi (dependent-name eol :flexi))
+                   (args (append (list enc :eol-style eol)
+                                 (loop
+                                    :for (k v) :on args :by #'cddr
+                                    :unless (eq k :type)
+                                    :nconc (list k v)))))
+              (print args)))
+              ;;(apply #'flexi-streams:make-external-format args)))
+
+    (:impl (let ((enc-on-impl (independent-name enc))
+                 (eol-on-impl (independent-name eol)))
+             (declare (ignorable eol-on-impl))
+             #+clisp (ext:make-encoding :charset enc-on-impl
+                                        :line-terminator eol-on-impl)
+             #+ecl `(,enc-on-impl ,eol-on-impl)
+             #+sbcl enc-on-impl
+             #+ccl (ccl:make-external-format :character-encoding enc-on-impl
+                                             :line-termination eol-on-impl)
+             #+abcl `(,enc-on-impl :eol-style ,eol-on-impl)
+             #-(or clisp ecl sbcl ccl abcl)
+             (error "your implementation is not supported.")))))

--- a/src/external-format.lisp
+++ b/src/external-format.lisp
@@ -6,26 +6,20 @@
                 :dependent-name))
 (in-package :inquisitor.external-format)
 
+(defgeneric make-external-format
+    (type enc eol &rest args &key &allow-other-keys))
 
-(defun make-external-format (enc eol &rest args &key (type :impl) &allow-other-keys)
-  (ecase type
-    (:flexi (let* ((enc-flexi (dependent-name enc :flexi))
-                   (eol-flexi (dependent-name eol :flexi))
-                   (args (append (list enc :eol-style eol)
-                                 (loop
-                                    :for (k v) :on args :by #'cddr
-                                    :unless (eq k :type)
-                                    :nconc (list k v)))))
-              #+flexi-streams (apply #'flexi-streams:make-external-format args)))
-    (:impl (let ((enc-on-impl (dependent-name enc))
-                 (eol-on-impl (dependent-name eol)))
-             (declare (ignorable eol-on-impl))
-             #+clisp (ext:make-encoding :charset enc-on-impl
-                                        :line-terminator eol-on-impl)
-             #+ecl `(,enc-on-impl ,eol-on-impl)
-             #+sbcl enc-on-impl
-             #+ccl (ccl:make-external-format :character-encoding enc-on-impl
-                                             :line-termination eol-on-impl)
-             #+abcl `(,enc-on-impl :eol-style ,eol-on-impl)
-             #-(or clisp ecl sbcl ccl abcl)
-             (error "your implementation is not supported.")))))
+(defmethod make-external-format
+    ((type (eql :impl)) enc eol &rest args &key &allow-other-keys)
+  (let ((enc-on-impl (dependent-name enc))
+        (eol-on-impl (dependent-name eol)))
+    (declare (ignorable eol-on-impl))
+    #+clisp (ext:make-encoding :charset enc-on-impl
+                               :line-terminator eol-on-impl)
+    #+ecl `(,enc-on-impl ,eol-on-impl)
+    #+sbcl enc-on-impl
+    #+ccl (ccl:make-external-format :character-encoding enc-on-impl
+                                    :line-termination eol-on-impl)
+    #+abcl `(,enc-on-impl :eol-style ,eol-on-impl)
+    #-(or clisp ecl sbcl ccl abcl)
+    (error "your implementation is not supported.")))

--- a/src/external-format.lisp
+++ b/src/external-format.lisp
@@ -3,8 +3,7 @@
   (:use :cl)
   (:export :make-external-format)
   (:import-from :inquisitor.names
-                :dependent-name
-                :independent-name))
+                :dependent-name))
 (in-package :inquisitor.external-format)
 
 
@@ -20,8 +19,8 @@
               (print args)))
               ;;(apply #'flexi-streams:make-external-format args)))
 
-    (:impl (let ((enc-on-impl (independent-name enc))
-                 (eol-on-impl (independent-name eol)))
+    (:impl (let ((enc-on-impl (dependent-name enc))
+                 (eol-on-impl (dependent-name eol)))
              (declare (ignorable eol-on-impl))
              #+clisp (ext:make-encoding :charset enc-on-impl
                                         :line-terminator eol-on-impl)

--- a/src/external-format.lisp
+++ b/src/external-format.lisp
@@ -16,7 +16,7 @@
                                     :for (k v) :on args :by #'cddr
                                     :unless (eq k :type)
                                     :nconc (list k v)))))
-              #+:flexi-streams (apply #'flexi-streams:make-external-format args)))
+              #+flexi-streams (apply #'flexi-streams:make-external-format args)))
     (:impl (let ((enc-on-impl (dependent-name enc))
                  (eol-on-impl (dependent-name eol)))
              (declare (ignorable eol-on-impl))

--- a/src/external-format.lisp
+++ b/src/external-format.lisp
@@ -16,9 +16,7 @@
                                     :for (k v) :on args :by #'cddr
                                     :unless (eq k :type)
                                     :nconc (list k v)))))
-              (print args)))
-              ;;(apply #'flexi-streams:make-external-format args)))
-
+              #+:flexi-streams (apply #'flexi-streams:make-external-format args)))
     (:impl (let ((enc-on-impl (dependent-name enc))
                  (eol-on-impl (dependent-name eol)))
              (declare (ignorable eol-on-impl))

--- a/src/inquisitor.lisp
+++ b/src/inquisitor.lisp
@@ -125,8 +125,8 @@ file position."
             (values nil (list enc eol))
             (values
              (if eol-impl
-                 (make-external-format enc-impl eol-impl)
-                 (make-external-format enc-impl :lf))
+                 (make-external-format :impl enc-impl eol-impl)
+                 (make-external-format :impl enc-impl :lf))
              (list enc eol))))
       (error (format nil "supllied vector is not a byte array."))))
 
@@ -159,8 +159,8 @@ method modifies `stream`'s file position."
               (values nil (list encoding end-of-line))
               (values
                (if eol-impl
-                   (make-external-format enc-impl eol-impl)
-                   (make-external-format enc-impl :lf))
+                   (make-external-format :impl enc-impl eol-impl)
+                   (make-external-format :impl enc-impl :lf))
                (list encoding end-of-line)))))
       (error (format nil "supplied stream is not a byte input stream."))))
 

--- a/src/names.lisp
+++ b/src/names.lisp
@@ -17,6 +17,7 @@
 
     (:name :utf-8
      :type :unicode
+     :flexi-name :utf-8
      :impl-name
      #+sbcl :utf-8
      #+ccl :utf-8
@@ -29,6 +30,7 @@
     ;; TODO: UCS-2 == UTF16? strictly?
     (:name :ucs-2le
      :type :unicode
+     :flexi-name nil
      :impl-name
      #+sbcl :utf-16le
      #+ccl :utf-16le
@@ -40,6 +42,7 @@
 
     (:name :ucs-2be
      :type :unicode
+     :flexi-name nil
      :impl-name
      #+sbcl :utf-16be
      #+ccl :utf-16be
@@ -51,6 +54,7 @@
 
     (:name :utf-16
      :type :unicode
+     :flexi-name :utf-16
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :utf-16
@@ -64,6 +68,7 @@
 
     (:name :iso-2022-jp
      :type :jp
+     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -75,6 +80,7 @@
 
     (:name :euc-jp
      :type :jp
+     :flexi-name nil
      :impl-name
      #+sbcl :euc-jp
      #+ccl :euc-jp
@@ -86,6 +92,7 @@
 
     (:name :cp932
      :type :jp
+     :flexi-name nil
      :impl-name
      #+sbcl :shift_jis
      #+ccl :windows-31j
@@ -99,6 +106,7 @@
 
     (:name :big5
      :type :tw
+     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -110,6 +118,7 @@
 
     (:name :iso-2022-tw
      :type :tw
+     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -123,6 +132,7 @@
 
     (:name :gb2312
      :type :cn
+     :flexi-name nil
      :impl-name
      #+sbcl :gbk
      #+ccl :cp936
@@ -134,6 +144,7 @@
 
     (:name :gb18030
      :type :cn
+     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -145,6 +156,7 @@
 
     (:name :iso-2022-cn
      :type :cn
+     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -158,6 +170,7 @@
 
     (:name :euc-kr
      :type :kr
+     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -169,6 +182,7 @@
 
     (:name :johab
      :type :kr
+     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -180,6 +194,7 @@
 
     (:name :iso-2022-kr
      :type :kr
+     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -193,6 +208,7 @@
 
     (:name :iso-8859-6
      :type :ar
+     :flexi-name :iso-8859-6
      :impl-name
      #+sbcl :iso-8859-6
      #+ccl :iso-8859-6
@@ -204,6 +220,7 @@
 
     (:name :cp1256
      :type :ar
+     :flexi-name nil
      :impl-name
      #+sbcl :cp1256
      #+ccl :cannot-treat
@@ -217,6 +234,7 @@
 
     (:name :iso-8859-7
      :type :gr
+     :flexi-name :iso-8859-7
      :impl-name
      #+sbcl :iso-8859-7
      #+ccl :iso-8859-7
@@ -228,6 +246,7 @@
 
     (:name :cp1253
      :type :gr
+     :flexi-name nil
      :impl-name
      #+sbcl :cp1253
      #+ccl :cannot-treat
@@ -241,6 +260,7 @@
 
     (:name :iso-8859-8
      :type :hw
+     :flexi-name :iso-8859-8
      :impl-name
      #+sbcl :iso-8859-8
      #+ccl :iso-8859-8
@@ -252,6 +272,7 @@
 
     (:name :cp1255
      :type :hw
+     :flexi-name nil
      :impl-name
      #+sbcl :cp1255
      #+ccl :cannot-treat
@@ -265,6 +286,7 @@
 
     (:name :iso-8859-9
      :type :tr
+     :flexi-name :iso-8859-9
      :impl-name
      #+sbcl :iso-8859-9
      #+ccl :iso-8859-9
@@ -276,6 +298,7 @@
 
     (:name :cp1254
      :type :tr
+     :flexi-name nil
      :impl-name
      #+sbcl :cp1254
      #+ccl :cannot-treat
@@ -289,6 +312,7 @@
 
     (:name :iso-8859-5
      :type :ru
+     :flexi-name :iso-8859-5
      :impl-name
      #+sbcl :iso-8859-5
      #+ccl :iso-8859-5
@@ -300,6 +324,7 @@
 
     (:name :koi8-r
      :type :ru
+     :flexi-name :koi8-r
      :impl-name
      #+sbcl :koi8-r
      #+ccl :cannot-treat
@@ -311,6 +336,7 @@
 
     (:name :koi8-u
      :type :ru
+     :flexi-name nil
      :impl-name
      #+sbcl :koi8-u
      #+ccl :cannot-treat
@@ -322,6 +348,7 @@
 
     (:name :cp866
      :type :ru
+     :flexi-name nil
      :impl-name
      #+sbcl :cp866
      #+ccl :cannot-treat
@@ -333,6 +360,7 @@
 
     (:name :cp1251
      :type :ru
+     :flexi-name nil
      :impl-name
      #+sbcl :cp1251
      #+ccl :cannot-treat
@@ -346,6 +374,7 @@
 
     (:name :iso-8859-2
      :type :pl
+     :flexi-name :iso-8859-2
      :impl-name
      #+sbcl :iso-8859-2
      #+ccl :iso-8859-2
@@ -357,6 +386,7 @@
 
     (:name :cp1250
      :type :pl
+     :flexi-name nil
      :impl-name
      #+sbcl :cp1250
      #+ccl :cannot-treat
@@ -370,6 +400,7 @@
 
     (:name :iso-8859-13
      :type :bl
+     :flexi-name :iso-8859-13
      :impl-name
      #+sbcl :iso-8859-13
      #+ccl :iso-8859-13
@@ -381,6 +412,7 @@
 
     (:name :cp1257
      :type :bl
+     :flexi-name nil
      :impl-name
      #+sbcl :cp1257
      #+ccl :cannot-treat
@@ -394,6 +426,7 @@
 
     (:name :lf
      :type :eol
+     :flexi-name :lf
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :unix
@@ -405,6 +438,7 @@
 
     (:name :cr
      :type :eol
+     :flexi-name :cr
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :macos
@@ -416,6 +450,7 @@
 
     (:name :crlf
      :type :eol
+     :flexi-name :crlf
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :dos
@@ -449,10 +484,12 @@
                  +name-mapping+)
         :name))
 
-(defun dependent-name (independent-name)
-  (getf (find-if (lambda (enc) (eq (getf enc :name) independent-name))
-                 +name-mapping+)
-        :impl-name))
+(defun dependent-name (independent-name &optional type)
+  (let ((encoding (find-if (lambda (enc) (eq (getf enc :name) independent-name))
+                           +name-mapping+)))
+    (if type
+        (getf encoding type)
+        (getf encoding :impl-name))))
 
 (defun unicode-p (independent-name)
   (member independent-name

--- a/src/names.lisp
+++ b/src/names.lisp
@@ -476,9 +476,9 @@
      :when (eq type :eol)
      :collect name))
 
-(defun independent-name (dependent-name)
+(defun independent-name (dependent-name &optional type)
   (getf (find-if (lambda (enc)
-                   (let ((impl-name (getf enc :impl-name)))
+                   (let ((impl-name (getf enc (if type type :impl-name))))
                      (and (not (eq impl-name :cannot-treat))
                           (eq impl-name dependent-name))))
                  +name-mapping+)

--- a/src/names.lisp
+++ b/src/names.lisp
@@ -17,7 +17,6 @@
 
     (:name :utf-8
      :type :unicode
-     :flexi-name :utf-8
      :impl-name
      #+sbcl :utf-8
      #+ccl :utf-8
@@ -30,7 +29,6 @@
     ;; TODO: UCS-2 == UTF16? strictly?
     (:name :ucs-2le
      :type :unicode
-     :flexi-name nil
      :impl-name
      #+sbcl :utf-16le
      #+ccl :utf-16le
@@ -42,7 +40,6 @@
 
     (:name :ucs-2be
      :type :unicode
-     :flexi-name nil
      :impl-name
      #+sbcl :utf-16be
      #+ccl :utf-16be
@@ -54,7 +51,6 @@
 
     (:name :utf-16
      :type :unicode
-     :flexi-name :utf-16
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :utf-16
@@ -68,7 +64,6 @@
 
     (:name :iso-2022-jp
      :type :jp
-     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -80,7 +75,6 @@
 
     (:name :euc-jp
      :type :jp
-     :flexi-name nil
      :impl-name
      #+sbcl :euc-jp
      #+ccl :euc-jp
@@ -92,7 +86,6 @@
 
     (:name :cp932
      :type :jp
-     :flexi-name nil
      :impl-name
      #+sbcl :shift_jis
      #+ccl :windows-31j
@@ -106,7 +99,6 @@
 
     (:name :big5
      :type :tw
-     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -118,7 +110,6 @@
 
     (:name :iso-2022-tw
      :type :tw
-     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -132,7 +123,6 @@
 
     (:name :gb2312
      :type :cn
-     :flexi-name nil
      :impl-name
      #+sbcl :gbk
      #+ccl :cp936
@@ -144,7 +134,6 @@
 
     (:name :gb18030
      :type :cn
-     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -156,7 +145,6 @@
 
     (:name :iso-2022-cn
      :type :cn
-     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -170,7 +158,6 @@
 
     (:name :euc-kr
      :type :kr
-     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -182,7 +169,6 @@
 
     (:name :johab
      :type :kr
-     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -194,7 +180,6 @@
 
     (:name :iso-2022-kr
      :type :kr
-     :flexi-name nil
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :cannot-treat
@@ -208,7 +193,6 @@
 
     (:name :iso-8859-6
      :type :ar
-     :flexi-name :iso-8859-6
      :impl-name
      #+sbcl :iso-8859-6
      #+ccl :iso-8859-6
@@ -220,7 +204,6 @@
 
     (:name :cp1256
      :type :ar
-     :flexi-name nil
      :impl-name
      #+sbcl :cp1256
      #+ccl :cannot-treat
@@ -234,7 +217,6 @@
 
     (:name :iso-8859-7
      :type :gr
-     :flexi-name :iso-8859-7
      :impl-name
      #+sbcl :iso-8859-7
      #+ccl :iso-8859-7
@@ -246,7 +228,6 @@
 
     (:name :cp1253
      :type :gr
-     :flexi-name nil
      :impl-name
      #+sbcl :cp1253
      #+ccl :cannot-treat
@@ -260,7 +241,6 @@
 
     (:name :iso-8859-8
      :type :hw
-     :flexi-name :iso-8859-8
      :impl-name
      #+sbcl :iso-8859-8
      #+ccl :iso-8859-8
@@ -272,7 +252,6 @@
 
     (:name :cp1255
      :type :hw
-     :flexi-name nil
      :impl-name
      #+sbcl :cp1255
      #+ccl :cannot-treat
@@ -286,7 +265,6 @@
 
     (:name :iso-8859-9
      :type :tr
-     :flexi-name :iso-8859-9
      :impl-name
      #+sbcl :iso-8859-9
      #+ccl :iso-8859-9
@@ -298,7 +276,6 @@
 
     (:name :cp1254
      :type :tr
-     :flexi-name nil
      :impl-name
      #+sbcl :cp1254
      #+ccl :cannot-treat
@@ -312,7 +289,6 @@
 
     (:name :iso-8859-5
      :type :ru
-     :flexi-name :iso-8859-5
      :impl-name
      #+sbcl :iso-8859-5
      #+ccl :iso-8859-5
@@ -324,7 +300,6 @@
 
     (:name :koi8-r
      :type :ru
-     :flexi-name :koi8-r
      :impl-name
      #+sbcl :koi8-r
      #+ccl :cannot-treat
@@ -336,7 +311,6 @@
 
     (:name :koi8-u
      :type :ru
-     :flexi-name nil
      :impl-name
      #+sbcl :koi8-u
      #+ccl :cannot-treat
@@ -348,7 +322,6 @@
 
     (:name :cp866
      :type :ru
-     :flexi-name nil
      :impl-name
      #+sbcl :cp866
      #+ccl :cannot-treat
@@ -360,7 +333,6 @@
 
     (:name :cp1251
      :type :ru
-     :flexi-name nil
      :impl-name
      #+sbcl :cp1251
      #+ccl :cannot-treat
@@ -374,7 +346,6 @@
 
     (:name :iso-8859-2
      :type :pl
-     :flexi-name :iso-8859-2
      :impl-name
      #+sbcl :iso-8859-2
      #+ccl :iso-8859-2
@@ -386,7 +357,6 @@
 
     (:name :cp1250
      :type :pl
-     :flexi-name nil
      :impl-name
      #+sbcl :cp1250
      #+ccl :cannot-treat
@@ -400,7 +370,6 @@
 
     (:name :iso-8859-13
      :type :bl
-     :flexi-name :iso-8859-13
      :impl-name
      #+sbcl :iso-8859-13
      #+ccl :iso-8859-13
@@ -412,7 +381,6 @@
 
     (:name :cp1257
      :type :bl
-     :flexi-name nil
      :impl-name
      #+sbcl :cp1257
      #+ccl :cannot-treat
@@ -426,7 +394,6 @@
 
     (:name :lf
      :type :eol
-     :flexi-name :lf
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :unix
@@ -438,7 +405,6 @@
 
     (:name :cr
      :type :eol
-     :flexi-name :cr
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :macos
@@ -450,7 +416,6 @@
 
     (:name :crlf
      :type :eol
-     :flexi-name :crlf
      :impl-name
      #+sbcl :cannot-treat
      #+ccl :dos

--- a/t/ext/flexi-streams.lisp
+++ b/t/ext/flexi-streams.lisp
@@ -1,0 +1,94 @@
+(in-package :cl-user)
+(defpackage :inquisitor-test.ext.flexi-streams
+  (:use :cl
+        :inquisitor.external-format
+        :inquisitor.names
+        :prove))
+(in-package :inquisitor-test.ext.flexi-streams)
+
+(plan 2)
+
+(subtest "names on flexi-streams"
+  (subtest "unicode"
+    (is (dependent-name :utf-8 :flexi-name) :utf-8)
+    (is (independent-name :utf-8 :flexi-name) :utf-8)
+    (is (dependent-name :ucs-2le :flexi-name) nil)
+    (is (dependent-name :ucs-2be :flexi-name) nil)
+    (is (dependent-name :utf-16 :flexi-name) :utf-16)
+    (is (independent-name :utf-16 :flexi-name) :utf-16))
+
+  (subtest "japanese"
+    (is (dependent-name :iso-2022-jp :flexi-name) nil)
+    (is (dependent-name :euc-jp :flexi-name) nil)
+    (is (dependent-name :cp932 :flexi-name) nil))
+
+  (subtest "taiwanese"
+    (is (dependent-name :big5 :flexi-name) nil)
+    (is (dependent-name :iso-2022-tw :flexi-name) nil))
+
+  (subtest "chinese"
+    (is (dependent-name :gb2312 :flexi-name) nil)
+    (is (dependent-name :gb18030 :flexi-name) nil)
+    (is (dependent-name :iso-2022-cn :flexi-name) nil))
+
+  (subtest "korean"
+    (is (dependent-name :euc-kr :flexi-name) nil)
+    (is (dependent-name :johab :flexi-name) nil)
+    (is (dependent-name :iso-2022-kr :flexi-name) nil))
+
+  (subtest "arabic"
+    (is (dependent-name :iso-8859-6 :flexi-name) :iso-8859-6)
+    (is (independent-name :iso-8859-6 :flexi-name) :iso-8859-6)
+    (is (dependent-name :cp1256 :flexi-name) nil))
+
+  (subtest "greek"
+    (is (dependent-name :iso-8859-7 :flexi-name) :iso-8859-7)
+    (is (independent-name :iso-8859-7 :flexi-name) :iso-8859-7)
+    (is (dependent-name :cp1253 :flexi-name) nil))
+
+  (subtest "hebrew"
+    (is (dependent-name :iso-8859-8 :flexi-name) :iso-8859-8)
+    (is (independent-name :iso-8859-8 :flexi-name) :iso-8859-8)
+    (is (dependent-name :cp1255 :flexi-name) nil))
+
+  (subtest "turkish"
+    (is (dependent-name :iso-8859-9 :flexi-name) :iso-8859-9)
+    (is (independent-name :iso-8859-9 :flexi-name) :iso-8859-9)
+    (is (dependent-name :cp1254 :flexi-name) nil))
+
+  (subtest "russian"
+    (is (dependent-name :iso-8859-5 :flexi-name) :iso-8859-5)
+    (is (independent-name :iso-8859-5 :flexi-name) :iso-8859-5)
+    (is (dependent-name :koi8-r :flexi-name) :koi8-r)
+    (is (independent-name :koi8-r :flexi-name) :koi8-r)
+    (is (dependent-name :koi8-u :flexi-name) nil)
+    (is (dependent-name :cp866 :flexi-name) nil)
+    (is (dependent-name :cp1251 :flexi-name) nil))
+
+  (subtest "polish"
+    (is (dependent-name :iso-8859-2 :flexi-name) :iso-8859-2)
+    (is (independent-name :iso-8859-2 :flexi-name) :iso-8859-2)
+    (is (dependent-name :cp1250 :flexi-name) nil))
+
+  (subtest "baltic"
+    (is (dependent-name :iso-8859-13 :flexi-name) :iso-8859-13)
+    (is (independent-name :iso-8859-13 :flexi-name) :iso-8859-13)
+    (is (dependent-name :cp1257 :flexi-name) nil))
+
+  (subtest "eol"
+    (is (dependent-name :lf :flexi-name) :lf)
+    (is (independent-name :lf :flexi-name) :lf)
+    (is (dependent-name :cr :flexi-name) :cr)
+    (is (independent-name :cr :flexi-name) :cr)
+    (is (dependent-name :crlf :flexi-name) :crlf)
+    (is (independent-name :crlf :flexi-name) :crlf)))
+
+(subtest "make external-format for flexi-streams"
+  (let* ((utf-8 (dependent-name :utf-8 :flexi-name))
+         (lf (dependent-name :lf :flexi-name))
+         (ef (make-external-format :flexi utf-8 lf :little-endian nil)))
+    (is (slot-value ef 'flex::name) :utf-8)
+    (is (slot-value ef 'flex::eol-style) :lf)
+    (is (slot-value ef 'flex::little-endian) nil)))
+
+(finalize)

--- a/t/external-format.lisp
+++ b/t/external-format.lisp
@@ -6,28 +6,18 @@
         :prove))
 (in-package :inquisitor-test.external-format)
 
-(plan 2)
+(plan 1)
 
 (subtest "make-external-format"
   (let* ((utf-8 (dependent-name :utf-8))
          (lf (dependent-name :lf)))
     (declare (ignorable lf))
-    (is (make-external-format :utf-8 :lf)
+    (is (make-external-format :impl :utf-8 :lf)
         #+clisp (ext:make-encoding :charset utf-8 :line-terminator lf)
         #+ecl (list utf-8 lf)
         #+sbcl utf-8
         #+ccl (ccl:make-external-format :character-encoding utf-8
                                         :line-termination lf)
         #+abcl (list utf-8 :eol-style lf))))
-
-(subtest "make external-format for flexi-streams"
-  #+flexi-streams
-  ;;; how can I run it?
-  (let* ((utf-8 (dependent-name :utf-8 :flexi-name))
-         (lf (dependent-name :lf :flexi-name))
-         (ef (make-external-format utf-8 lf :type :flexi :little-endian nil)))
-    (is (slot-value ef 'flex::name) :utf-8)
-    (is (slot-value ef 'flex::eol-style) :lf)
-    (is (slot-value ef 'flex::little-endian) nil)))
 
 (finalize)

--- a/t/external-format.lisp
+++ b/t/external-format.lisp
@@ -10,8 +10,8 @@
 
 
 (subtest "make-external-format"
-  (let* ((utf-8 (independent-name :utf-8))
-         (lf (independent-name :lf)))
+  (let* ((utf-8 (dependent-name :utf-8))
+         (lf (dependent-name :lf)))
     (declare (ignorable lf))
     (is (make-external-format :utf-8 :lf)
         #+clisp (ext:make-encoding :charset utf-8 :line-terminator lf)

--- a/t/external-format.lisp
+++ b/t/external-format.lisp
@@ -6,8 +6,7 @@
         :prove))
 (in-package :inquisitor-test.external-format)
 
-(plan 1)
-
+(plan 2)
 
 (subtest "make-external-format"
   (let* ((utf-8 (dependent-name :utf-8))
@@ -21,5 +20,14 @@
                                         :line-termination lf)
         #+abcl (list utf-8 :eol-style lf))))
 
+(subtest "make external-format for flexi-streams"
+  #+flexi-streams
+  ;;; how can I run it?
+  (let* ((utf-8 (dependent-name :utf-8 :flexi-name))
+         (lf (dependent-name :lf :flexi-name))
+         (ef (make-external-format utf-8 lf :type :flexi :little-endian nil)))
+    (is (slot-value ef 'flex::name) :utf-8)
+    (is (slot-value ef 'flex::eol-style) :lf)
+    (is (slot-value ef 'flex::little-endian) nil)))
 
 (finalize)

--- a/t/inquisitor.lisp
+++ b/t/inquisitor.lisp
@@ -72,7 +72,7 @@
   (is-error (detect-external-format "" :jp) 'error)
   (let ((str (string-to-octets "string")))
     (is (detect-external-format str :jp)
-        (make-external-format :utf-8 :lf))))
+        (make-external-format :impl :utf-8 :lf))))
 
 (subtest "detect external-format --- from stream"
   (with-output-to-string (out)
@@ -83,13 +83,13 @@
                       :direction :input
                       :element-type '(unsigned-byte 8))
     (is (detect-external-format in :jp)
-        (make-external-format :utf-8 :lf))))
+        (make-external-format :impl :utf-8 :lf))))
 
 (subtest "detect external-format --- from pathname"
   (is-error (detect-external-format "t/data/ascii/ascii-lf.txt" :jp) 'error)
   (is (detect-external-format (asdf:system-relative-pathname
                                :inquisitor "t/data/ascii/ascii-lf.txt") :jp)
-      (make-external-format :utf-8 :lf)))
+      (make-external-format :impl :utf-8 :lf)))
 
 
 (finalize)

--- a/t/names.lisp
+++ b/t/names.lisp
@@ -7,7 +7,7 @@
 
 ;; NOTE: To run this test file, execute `(asdf:test-system :inquisitor)' in your Lisp.
 
-(plan 18)
+(plan 16)
 
 (is +available-encodings+
       ;; unicode
@@ -403,112 +403,37 @@
       (is (independent-name impl-enc) :cp1257))))
 
 (subtest "end of line"
-  (let ((impl-eol #+sbcl :cannot-treat
-                  #+ccl :unix
-                  #+clisp :unix
-                  #+ecl :lf
-                  #+abcl :lf
-                  ;; https://franz.com/support/documentation/10.1/doc/operators/excl/eol-convention.htm
-                  #+allegro :unix
-                  #+lispworks :lf))
-    (is (dependent-name :lf) impl-eol)
-    (unless (eq impl-eol :cannot-treat)
-      (is (independent-name impl-eol) :lf)))
-  (let ((impl-eol #+sbcl :cannot-treat
-                  #+ccl :macos
-                  #+clisp :mac
-                  #+ecl :cr
-                  #+abcl :cr
-                  #+allegro :mac
-                  #+lispworks :cr))
-    (is (dependent-name :cr) impl-eol)
-    (unless (eq impl-eol :cannot-treat)
-      (is (independent-name impl-eol) :cr)))
-  (let ((impl-eol #+sbcl :cannot-treat
-                  #+ccl :dos
-                  #+clisp :dos
-                  #+ecl :crlf
-                  #+abcl :crlf
-                  #+allegro :doc
-                  #+lispworks :crlf))
-    (is (dependent-name :crlf) impl-eol)
-    (unless (eq impl-eol :cannot-treat)
-      (is (independent-name impl-eol) :crlf))))
-
-(subtest "names on flexi-streams"
-  (subtest "unicode"
-    (is (dependent-name :utf-8 :flexi-name) :utf-8)
-    (is (independent-name :utf-8 :flexi-name) :utf-8)
-    (is (dependent-name :ucs-2le :flexi-name) nil)
-    (is (dependent-name :ucs-2be :flexi-name) nil)
-    (is (dependent-name :utf-16 :flexi-name) :utf-16)
-    (is (independent-name :utf-16 :flexi-name) :utf-16))
-
-  (subtest "japanese"
-    (is (dependent-name :iso-2022-jp :flexi-name) nil)
-    (is (dependent-name :euc-jp :flexi-name) nil)
-    (is (dependent-name :cp932 :flexi-name) nil))
-
-  (subtest "taiwanese"
-    (is (dependent-name :big5 :flexi-name) nil)
-    (is (dependent-name :iso-2022-tw :flexi-name) nil))
-
-  (subtest "chinese"
-    (is (dependent-name :gb2312 :flexi-name) nil)
-    (is (dependent-name :gb18030 :flexi-name) nil)
-    (is (dependent-name :iso-2022-cn :flexi-name) nil))
-
-  (subtest "korean"
-    (is (dependent-name :euc-kr :flexi-name) nil)
-    (is (dependent-name :johab :flexi-name) nil)
-    (is (dependent-name :iso-2022-kr :flexi-name) nil))
-
-  (subtest "arabic"
-    (is (dependent-name :iso-8859-6 :flexi-name) :iso-8859-6)
-    (is (independent-name :iso-8859-6 :flexi-name) :iso-8859-6)
-    (is (dependent-name :cp1256 :flexi-name) nil))
-
-  (subtest "greek"
-    (is (dependent-name :iso-8859-7 :flexi-name) :iso-8859-7)
-    (is (independent-name :iso-8859-7 :flexi-name) :iso-8859-7)
-    (is (dependent-name :cp1253 :flexi-name) nil))
-
-  (subtest "hebrew"
-    (is (dependent-name :iso-8859-8 :flexi-name) :iso-8859-8)
-    (is (independent-name :iso-8859-8 :flexi-name) :iso-8859-8)
-    (is (dependent-name :cp1255 :flexi-name) nil))
-
-  (subtest "turkish"
-    (is (dependent-name :iso-8859-9 :flexi-name) :iso-8859-9)
-    (is (independent-name :iso-8859-9 :flexi-name) :iso-8859-9)
-    (is (dependent-name :cp1254 :flexi-name) nil))
-
-  (subtest "russian"
-    (is (dependent-name :iso-8859-5 :flexi-name) :iso-8859-5)
-    (is (independent-name :iso-8859-5 :flexi-name) :iso-8859-5)
-    (is (dependent-name :koi8-r :flexi-name) :koi8-r)
-    (is (independent-name :koi8-r :flexi-name) :koi8-r)
-    (is (dependent-name :koi8-u :flexi-name) nil)
-    (is (dependent-name :cp866 :flexi-name) nil)
-    (is (dependent-name :cp1251 :flexi-name) nil))
-
-  (subtest "polish"
-    (is (dependent-name :iso-8859-2 :flexi-name) :iso-8859-2)
-    (is (independent-name :iso-8859-2 :flexi-name) :iso-8859-2)
-    (is (dependent-name :cp1250 :flexi-name) nil))
-
-  (subtest "baltic"
-    (is (dependent-name :iso-8859-13 :flexi-name) :iso-8859-13)
-    (is (independent-name :iso-8859-13 :flexi-name) :iso-8859-13)
-    (is (dependent-name :cp1257 :flexi-name) nil))
-
-  (subtest "eol"
-    (is (dependent-name :lf :flexi-name) :lf)
-    (is (independent-name :lf :flexi-name) :lf)
-    (is (dependent-name :cr :flexi-name) :cr)
-    (is (independent-name :cr :flexi-name) :cr)
-    (is (dependent-name :crlf :flexi-name) :crlf)))
-    (is (independent-name :crlf :flexi-name) :crlf)
+         (let ((impl-eol #+sbcl :cannot-treat
+                         #+ccl :unix
+                         #+clisp :unix
+                         #+ecl :lf
+                         #+abcl :lf
+                         ;; https://franz.com/support/documentation/10.1/doc/operators/excl/eol-convention.htm
+                         #+allegro :unix
+                         #+lispworks :lf))
+           (is (dependent-name :lf) impl-eol)
+           (unless (eq impl-eol :cannot-treat)
+             (is (independent-name impl-eol) :lf)))
+         (let ((impl-eol #+sbcl :cannot-treat
+                         #+ccl :macos
+                         #+clisp :mac
+                         #+ecl :cr
+                         #+abcl :cr
+                         #+allegro :mac
+                         #+lispworks :cr))
+           (is (dependent-name :cr) impl-eol)
+           (unless (eq impl-eol :cannot-treat)
+             (is (independent-name impl-eol) :cr)))
+         (let ((impl-eol #+sbcl :cannot-treat
+                         #+ccl :dos
+                         #+clisp :dos
+                         #+ecl :crlf
+                         #+abcl :crlf
+                         #+allegro :doc
+                         #+lispworks :crlf))
+           (is (dependent-name :crlf) impl-eol)
+           (unless (eq impl-eol :cannot-treat)
+             (is (independent-name impl-eol) :crlf))))
 
 (subtest "if specified encodings is unicode?"
   (subtest "only unicode returns t"

--- a/t/names.lisp
+++ b/t/names.lisp
@@ -7,7 +7,7 @@
 
 ;; NOTE: To run this test file, execute `(asdf:test-system :inquisitor)' in your Lisp.
 
-(plan 16)
+(plan 18)
 
 (is +available-encodings+
       ;; unicode
@@ -438,9 +438,11 @@
 (subtest "names on flexi-streams"
   (subtest "unicode"
     (is (dependent-name :utf-8 :flexi-name) :utf-8)
+    (is (independent-name :utf-8 :flexi-name) :utf-8)
     (is (dependent-name :ucs-2le :flexi-name) nil)
     (is (dependent-name :ucs-2be :flexi-name) nil)
-    (is (dependent-name :utf-16 :flexi-name) :utf-16))
+    (is (dependent-name :utf-16 :flexi-name) :utf-16)
+    (is (independent-name :utf-16 :flexi-name) :utf-16))
 
   (subtest "japanese"
     (is (dependent-name :iso-2022-jp :flexi-name) nil)
@@ -463,39 +465,50 @@
 
   (subtest "arabic"
     (is (dependent-name :iso-8859-6 :flexi-name) :iso-8859-6)
+    (is (independent-name :iso-8859-6 :flexi-name) :iso-8859-6)
     (is (dependent-name :cp1256 :flexi-name) nil))
 
   (subtest "greek"
     (is (dependent-name :iso-8859-7 :flexi-name) :iso-8859-7)
+    (is (independent-name :iso-8859-7 :flexi-name) :iso-8859-7)
     (is (dependent-name :cp1253 :flexi-name) nil))
 
   (subtest "hebrew"
     (is (dependent-name :iso-8859-8 :flexi-name) :iso-8859-8)
+    (is (independent-name :iso-8859-8 :flexi-name) :iso-8859-8)
     (is (dependent-name :cp1255 :flexi-name) nil))
 
   (subtest "turkish"
     (is (dependent-name :iso-8859-9 :flexi-name) :iso-8859-9)
+    (is (independent-name :iso-8859-9 :flexi-name) :iso-8859-9)
     (is (dependent-name :cp1254 :flexi-name) nil))
 
   (subtest "russian"
     (is (dependent-name :iso-8859-5 :flexi-name) :iso-8859-5)
+    (is (independent-name :iso-8859-5 :flexi-name) :iso-8859-5)
     (is (dependent-name :koi8-r :flexi-name) :koi8-r)
+    (is (independent-name :koi8-r :flexi-name) :koi8-r)
     (is (dependent-name :koi8-u :flexi-name) nil)
     (is (dependent-name :cp866 :flexi-name) nil)
     (is (dependent-name :cp1251 :flexi-name) nil))
 
   (subtest "polish"
     (is (dependent-name :iso-8859-2 :flexi-name) :iso-8859-2)
+    (is (independent-name :iso-8859-2 :flexi-name) :iso-8859-2)
     (is (dependent-name :cp1250 :flexi-name) nil))
 
   (subtest "baltic"
     (is (dependent-name :iso-8859-13 :flexi-name) :iso-8859-13)
+    (is (independent-name :iso-8859-13 :flexi-name) :iso-8859-13)
     (is (dependent-name :cp1257 :flexi-name) nil))
 
   (subtest "eol"
     (is (dependent-name :lf :flexi-name) :lf)
+    (is (independent-name :lf :flexi-name) :lf)
     (is (dependent-name :cr :flexi-name) :cr)
+    (is (independent-name :cr :flexi-name) :cr)
     (is (dependent-name :crlf :flexi-name) :crlf)))
+    (is (independent-name :crlf :flexi-name) :crlf)
 
 (subtest "if specified encodings is unicode?"
   (subtest "only unicode returns t"

--- a/t/names.lisp
+++ b/t/names.lisp
@@ -66,7 +66,6 @@
              #+allegro :utf8
              #+lispworks :utf-8))
     (is (dependent-name :utf-8) impl-enc)
-    (is (dependent-name :utf-8 :flexi-name) :utf-8)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :utf-8)))
   (let ((impl-enc #+sbcl :utf-16le
@@ -77,7 +76,6 @@
              #+allegro :cannot-treat
              #+lispworks '(:unicode :little-endian)))
     (is (dependent-name :ucs-2le) impl-enc)
-    (is (dependent-name :ucs-2le :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :ucs-2le)))
   (let ((impl-enc #+sbcl :utf-16be
@@ -88,7 +86,6 @@
              #+allegro :cannot-treat
              #+lispworks '(:unicode :big-endian)))
     (is (dependent-name :ucs-2be) impl-enc)
-    (is (dependent-name :ucs-2be :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :ucs-2be)))
   (let ((impl-enc #+sbcl :cannot-treat
@@ -99,7 +96,6 @@
              #+allegro :cannot-treat
              #+lispworks :cannot-treat))
     (is (dependent-name :utf-16) impl-enc)
-    (is (dependent-name :utf-16 :flexi-name) :utf-16)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :utf-16))))
 
@@ -112,7 +108,6 @@
              #+allegro :jis
              #+lispworks :jis))
     (is (dependent-name :iso-2022-jp) impl-enc)
-    (is (dependent-name :iso-2022-jp :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-2022-jp)))
   (let ((impl-enc #+sbcl :euc-jp
@@ -123,7 +118,6 @@
              #+allegro :euc
              #+lispworks :euc-jp))
     (is (dependent-name :euc-jp) impl-enc)
-    (is (dependent-name :euc-jp :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :euc-jp)))
   (let ((impl-enc #+sbcl :shift_jis
@@ -134,7 +128,6 @@
              #+allegro :shiftjis
              #+lispworks :sjis))
     (is (dependent-name :cp932) impl-enc)
-    (is (dependent-name :cp932 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp932))))
 
@@ -147,7 +140,6 @@
                   #+allegro :big5
                   #+(and lispworks windows) '(win32:code-page :id 950)))
     (is (dependent-name :big5) impl-enc)
-    (is (dependent-name :big5 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :big5)))
    (let ((impl-enc #+clisp charset:euc-tw
@@ -158,7 +150,6 @@
                    #+allegro :cannot-treat
                    #+lispworks :cannot-treat))
      (is (dependent-name :iso-2022-tw) impl-enc)
-     (is (dependent-name :iso-2022-tw :flexi-name) nil)
      (unless (eq impl-enc :cannot-treat)
        (is (independent-name impl-enc) :iso-2022-tw))))
 
@@ -172,7 +163,6 @@
                   #+allegro :cannot-treat
                   #+lispworks :gbk))
     (is (dependent-name :gb2312) impl-enc)
-    (is (dependent-name :gb2312 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :gb2312)))
   (let ((impl-enc #+sbcl :cannot-treat
@@ -183,7 +173,6 @@
                   #+allegro :gb18030
                   #+lispworks :cannot-treat))
     (is (dependent-name :gb18030) impl-enc)
-    (is (dependent-name :gb18030 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :gb18030)))
   (let ((impl-enc #+sbcl :cannot-treat
@@ -194,7 +183,6 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-2022-cn) impl-enc)
-    (is (dependent-name :iso-2022-cn :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-2022-cn))))
 
@@ -207,7 +195,6 @@
                   #+allegro :949
                   #+(and lispworks windows) '(win32:code-page :id 949)))
     (is (dependent-name :euc-kr) impl-enc)
-    (is (dependent-name :euc-kr :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :euc-kr)))
   (let ((impl-enc #+sbcl :cannot-treat
@@ -218,7 +205,6 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :johab) impl-enc)
-    (is (dependent-name :johab :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :johab)))
   (let ((impl-enc #+sbcl :cannot-treat
@@ -229,7 +215,6 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-2022-kr) impl-enc)
-    (is (dependent-name :iso-2022-kr :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc):iso-2022-kr))))
 
@@ -242,7 +227,6 @@
                   #+allegro iso8859-6
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-6) impl-enc)
-    (is (dependent-name :iso-8859-6 :flexi-name) :iso-8859-6)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-6)))
   (let ((impl-enc #+sbcl :cp1256
@@ -253,7 +237,6 @@
                   #+allegro :1256
                   #+(and lispworks windows) '(win32:code-page :id 1256)))
     (is (dependent-name :cp1256) impl-enc)
-    (is (dependent-name :cp1256 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1256))))
 
@@ -266,7 +249,6 @@
                   #+allegro :iso8859-7
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-7) impl-enc)
-    (is (dependent-name :iso-8859-7 :flexi-name) :iso-8859-7)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-7)))
   (let ((impl-enc #+sbcl :cp1253
@@ -277,7 +259,6 @@
                   #+allegro :1253
                   #+(and lispworks windows) '(win32:code-page :id 1253)))
     (is (dependent-name :cp1253) impl-enc)
-    (is (dependent-name :cp1253 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1253))))
 
@@ -290,7 +271,6 @@
                   #+allegro :iso8859-8
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-8) impl-enc)
-    (is (dependent-name :iso-8859-8 :flexi-name) :iso-8859-8)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-8)))
   (let ((impl-enc #+sbcl :cp1255
@@ -301,7 +281,6 @@
                   #+allegro :1255
                   #+(and lispworks windows) '(win32:code-page :id 1255)))
     (is (dependent-name :cp1255) impl-enc)
-    (is (dependent-name :cp1255 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1255))))
 
@@ -314,7 +293,6 @@
                   #+allegro :iso8859-9
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-9) impl-enc)
-    (is (dependent-name :iso-8859-9 :flexi-name) :iso-8859-9)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-9)))
   (let ((impl-enc #+sbcl :cp1254
@@ -325,7 +303,6 @@
                   #+allegro :1254
                   #+(and lispworks windows) '(win32:code-page :id 1254)))
     (is (dependent-name :cp1254) impl-enc)
-    (is (dependent-name :cp1254 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1254))))
 
@@ -338,7 +315,6 @@
                   #+allegro :iso8859-5
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-5) impl-enc)
-    (is (dependent-name :iso-8859-5 :flexi-name) :iso-8859-5)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name  impl-enc):iso-8859-5)))
   (let ((impl-enc #+sbcl :koi8-r
@@ -349,7 +325,6 @@
                   #+allegro :koi8-r
                   #+lispworks :cannot-treat))
     (is (dependent-name :koi8-r) impl-enc)
-    (is (dependent-name :koi8-r :flexi-name) :koi8-r)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :koi8-r)))
   (let ((impl-enc #+sbcl :koi8-u
@@ -360,7 +335,6 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :koi8-u) impl-enc)
-    (is (dependent-name :koi8-u :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :koi8-u)))
   (let ((impl-enc #+sbcl :cp866
@@ -371,7 +345,6 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :cp866) impl-enc)
-    (is (dependent-name :cp866 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp866)))
   (let ((impl-enc #+sbcl :cp1251
@@ -382,7 +355,6 @@
                   #+allegro :1251
                   #+(and lispworks windows) '(win32:code-page :id 1251)))
     (is (dependent-name :cp1251) impl-enc)
-    (is (dependent-name :cp1251 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1251))))
 
@@ -395,7 +367,6 @@
                   #+allegro :iso8859-2
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-2) impl-enc)
-    (is (dependent-name :iso-8859-2 :flexi-name) :iso-8859-2)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-2)))
   (let ((impl-enc #+sbcl :cp1250
@@ -406,7 +377,6 @@
                   #+allegro :1250
                   #+(and lispworks windows) '(win32:code-page :id 1250)))
     (is (dependent-name :cp1250) impl-enc)
-    (is (dependent-name :cp1250 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1250))))
 
@@ -419,7 +389,6 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-13) impl-enc)
-    (is (dependent-name :iso-8859-13 :flexi-name) :iso-8859-13)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-13)))
   (let ((impl-enc #+sbcl :cp1257
@@ -430,7 +399,6 @@
                   #+allegro :1257
                   #+(and lispworks windows) '(win32:code-page :id 1257)))
     (is (dependent-name :cp1257) impl-enc)
-    (is (dependent-name :cp1257 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1257))))
 
@@ -444,7 +412,6 @@
                   #+allegro :unix
                   #+lispworks :lf))
     (is (dependent-name :lf) impl-eol)
-    (is (dependent-name :lf :flexi-name) :lf)
     (unless (eq impl-eol :cannot-treat)
       (is (independent-name impl-eol) :lf)))
   (let ((impl-eol #+sbcl :cannot-treat
@@ -455,7 +422,6 @@
                   #+allegro :mac
                   #+lispworks :cr))
     (is (dependent-name :cr) impl-eol)
-    (is (dependent-name :cr :flexi-name) :cr)
     (unless (eq impl-eol :cannot-treat)
       (is (independent-name impl-eol) :cr)))
   (let ((impl-eol #+sbcl :cannot-treat
@@ -466,9 +432,70 @@
                   #+allegro :doc
                   #+lispworks :crlf))
     (is (dependent-name :crlf) impl-eol)
-    (is (dependent-name :crlf :flexi-name) :crlf)
     (unless (eq impl-eol :cannot-treat)
       (is (independent-name impl-eol) :crlf))))
+
+(subtest "names on flexi-streams"
+  (subtest "unicode"
+    (is (dependent-name :utf-8 :flexi-name) :utf-8)
+    (is (dependent-name :ucs-2le :flexi-name) nil)
+    (is (dependent-name :ucs-2be :flexi-name) nil)
+    (is (dependent-name :utf-16 :flexi-name) :utf-16))
+
+  (subtest "japanese"
+    (is (dependent-name :iso-2022-jp :flexi-name) nil)
+    (is (dependent-name :euc-jp :flexi-name) nil)
+    (is (dependent-name :cp932 :flexi-name) nil))
+
+  (subtest "taiwanese"
+    (is (dependent-name :big5 :flexi-name) nil)
+    (is (dependent-name :iso-2022-tw :flexi-name) nil))
+
+  (subtest "chinese"
+    (is (dependent-name :gb2312 :flexi-name) nil)
+    (is (dependent-name :gb18030 :flexi-name) nil)
+    (is (dependent-name :iso-2022-cn :flexi-name) nil))
+
+  (subtest "korean"
+    (is (dependent-name :euc-kr :flexi-name) nil)
+    (is (dependent-name :johab :flexi-name) nil)
+    (is (dependent-name :iso-2022-kr :flexi-name) nil))
+
+  (subtest "arabic"
+    (is (dependent-name :iso-8859-6 :flexi-name) :iso-8859-6)
+    (is (dependent-name :cp1256 :flexi-name) nil))
+
+  (subtest "greek"
+    (is (dependent-name :iso-8859-7 :flexi-name) :iso-8859-7)
+    (is (dependent-name :cp1253 :flexi-name) nil))
+
+  (subtest "hebrew"
+    (is (dependent-name :iso-8859-8 :flexi-name) :iso-8859-8)
+    (is (dependent-name :cp1255 :flexi-name) nil))
+
+  (subtest "turkish"
+    (is (dependent-name :iso-8859-9 :flexi-name) :iso-8859-9)
+    (is (dependent-name :cp1254 :flexi-name) nil))
+
+  (subtest "russian"
+    (is (dependent-name :iso-8859-5 :flexi-name) :iso-8859-5)
+    (is (dependent-name :koi8-r :flexi-name) :koi8-r)
+    (is (dependent-name :koi8-u :flexi-name) nil)
+    (is (dependent-name :cp866 :flexi-name) nil)
+    (is (dependent-name :cp1251 :flexi-name) nil))
+
+  (subtest "polish"
+    (is (dependent-name :iso-8859-2 :flexi-name) :iso-8859-2)
+    (is (dependent-name :cp1250 :flexi-name) nil))
+
+  (subtest "baltic"
+    (is (dependent-name :iso-8859-13 :flexi-name) :iso-8859-13)
+    (is (dependent-name :cp1257 :flexi-name) nil))
+
+  (subtest "eol"
+    (is (dependent-name :lf :flexi-name) :lf)
+    (is (dependent-name :cr :flexi-name) :cr)
+    (is (dependent-name :crlf :flexi-name) :crlf)))
 
 (subtest "if specified encodings is unicode?"
   (subtest "only unicode returns t"

--- a/t/names.lisp
+++ b/t/names.lisp
@@ -66,6 +66,7 @@
              #+allegro :utf8
              #+lispworks :utf-8))
     (is (dependent-name :utf-8) impl-enc)
+    (is (dependent-name :utf-8 :flexi-name) :utf-8)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :utf-8)))
   (let ((impl-enc #+sbcl :utf-16le
@@ -76,6 +77,7 @@
              #+allegro :cannot-treat
              #+lispworks '(:unicode :little-endian)))
     (is (dependent-name :ucs-2le) impl-enc)
+    (is (dependent-name :ucs-2le :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :ucs-2le)))
   (let ((impl-enc #+sbcl :utf-16be
@@ -86,6 +88,7 @@
              #+allegro :cannot-treat
              #+lispworks '(:unicode :big-endian)))
     (is (dependent-name :ucs-2be) impl-enc)
+    (is (dependent-name :ucs-2be :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :ucs-2be)))
   (let ((impl-enc #+sbcl :cannot-treat
@@ -96,6 +99,7 @@
              #+allegro :cannot-treat
              #+lispworks :cannot-treat))
     (is (dependent-name :utf-16) impl-enc)
+    (is (dependent-name :utf-16 :flexi-name) :utf-16)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :utf-16))))
 
@@ -108,6 +112,7 @@
              #+allegro :jis
              #+lispworks :jis))
     (is (dependent-name :iso-2022-jp) impl-enc)
+    (is (dependent-name :iso-2022-jp :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-2022-jp)))
   (let ((impl-enc #+sbcl :euc-jp
@@ -118,6 +123,7 @@
              #+allegro :euc
              #+lispworks :euc-jp))
     (is (dependent-name :euc-jp) impl-enc)
+    (is (dependent-name :euc-jp :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :euc-jp)))
   (let ((impl-enc #+sbcl :shift_jis
@@ -128,6 +134,7 @@
              #+allegro :shiftjis
              #+lispworks :sjis))
     (is (dependent-name :cp932) impl-enc)
+    (is (dependent-name :cp932 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp932))))
 
@@ -140,6 +147,7 @@
                   #+allegro :big5
                   #+(and lispworks windows) '(win32:code-page :id 950)))
     (is (dependent-name :big5) impl-enc)
+    (is (dependent-name :big5 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :big5)))
    (let ((impl-enc #+clisp charset:euc-tw
@@ -150,6 +158,7 @@
                    #+allegro :cannot-treat
                    #+lispworks :cannot-treat))
      (is (dependent-name :iso-2022-tw) impl-enc)
+     (is (dependent-name :iso-2022-tw :flexi-name) nil)
      (unless (eq impl-enc :cannot-treat)
        (is (independent-name impl-enc) :iso-2022-tw))))
 
@@ -163,6 +172,7 @@
                   #+allegro :cannot-treat
                   #+lispworks :gbk))
     (is (dependent-name :gb2312) impl-enc)
+    (is (dependent-name :gb2312 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :gb2312)))
   (let ((impl-enc #+sbcl :cannot-treat
@@ -173,6 +183,7 @@
                   #+allegro :gb18030
                   #+lispworks :cannot-treat))
     (is (dependent-name :gb18030) impl-enc)
+    (is (dependent-name :gb18030 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :gb18030)))
   (let ((impl-enc #+sbcl :cannot-treat
@@ -183,6 +194,7 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-2022-cn) impl-enc)
+    (is (dependent-name :iso-2022-cn :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-2022-cn))))
 
@@ -195,6 +207,7 @@
                   #+allegro :949
                   #+(and lispworks windows) '(win32:code-page :id 949)))
     (is (dependent-name :euc-kr) impl-enc)
+    (is (dependent-name :euc-kr :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :euc-kr)))
   (let ((impl-enc #+sbcl :cannot-treat
@@ -205,6 +218,7 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :johab) impl-enc)
+    (is (dependent-name :johab :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :johab)))
   (let ((impl-enc #+sbcl :cannot-treat
@@ -215,6 +229,7 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-2022-kr) impl-enc)
+    (is (dependent-name :iso-2022-kr :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc):iso-2022-kr))))
 
@@ -227,6 +242,7 @@
                   #+allegro iso8859-6
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-6) impl-enc)
+    (is (dependent-name :iso-8859-6 :flexi-name) :iso-8859-6)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-6)))
   (let ((impl-enc #+sbcl :cp1256
@@ -237,6 +253,7 @@
                   #+allegro :1256
                   #+(and lispworks windows) '(win32:code-page :id 1256)))
     (is (dependent-name :cp1256) impl-enc)
+    (is (dependent-name :cp1256 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1256))))
 
@@ -249,6 +266,7 @@
                   #+allegro :iso8859-7
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-7) impl-enc)
+    (is (dependent-name :iso-8859-7 :flexi-name) :iso-8859-7)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-7)))
   (let ((impl-enc #+sbcl :cp1253
@@ -259,6 +277,7 @@
                   #+allegro :1253
                   #+(and lispworks windows) '(win32:code-page :id 1253)))
     (is (dependent-name :cp1253) impl-enc)
+    (is (dependent-name :cp1253 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1253))))
 
@@ -271,6 +290,7 @@
                   #+allegro :iso8859-8
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-8) impl-enc)
+    (is (dependent-name :iso-8859-8 :flexi-name) :iso-8859-8)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-8)))
   (let ((impl-enc #+sbcl :cp1255
@@ -281,6 +301,7 @@
                   #+allegro :1255
                   #+(and lispworks windows) '(win32:code-page :id 1255)))
     (is (dependent-name :cp1255) impl-enc)
+    (is (dependent-name :cp1255 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1255))))
 
@@ -293,6 +314,7 @@
                   #+allegro :iso8859-9
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-9) impl-enc)
+    (is (dependent-name :iso-8859-9 :flexi-name) :iso-8859-9)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-9)))
   (let ((impl-enc #+sbcl :cp1254
@@ -303,6 +325,7 @@
                   #+allegro :1254
                   #+(and lispworks windows) '(win32:code-page :id 1254)))
     (is (dependent-name :cp1254) impl-enc)
+    (is (dependent-name :cp1254 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1254))))
 
@@ -315,6 +338,7 @@
                   #+allegro :iso8859-5
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-5) impl-enc)
+    (is (dependent-name :iso-8859-5 :flexi-name) :iso-8859-5)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name  impl-enc):iso-8859-5)))
   (let ((impl-enc #+sbcl :koi8-r
@@ -325,6 +349,7 @@
                   #+allegro :koi8-r
                   #+lispworks :cannot-treat))
     (is (dependent-name :koi8-r) impl-enc)
+    (is (dependent-name :koi8-r :flexi-name) :koi8-r)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :koi8-r)))
   (let ((impl-enc #+sbcl :koi8-u
@@ -335,6 +360,7 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :koi8-u) impl-enc)
+    (is (dependent-name :koi8-u :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :koi8-u)))
   (let ((impl-enc #+sbcl :cp866
@@ -345,6 +371,7 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :cp866) impl-enc)
+    (is (dependent-name :cp866 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp866)))
   (let ((impl-enc #+sbcl :cp1251
@@ -355,6 +382,7 @@
                   #+allegro :1251
                   #+(and lispworks windows) '(win32:code-page :id 1251)))
     (is (dependent-name :cp1251) impl-enc)
+    (is (dependent-name :cp1251 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1251))))
 
@@ -367,6 +395,7 @@
                   #+allegro :iso8859-2
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-2) impl-enc)
+    (is (dependent-name :iso-8859-2 :flexi-name) :iso-8859-2)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-2)))
   (let ((impl-enc #+sbcl :cp1250
@@ -377,6 +406,7 @@
                   #+allegro :1250
                   #+(and lispworks windows) '(win32:code-page :id 1250)))
     (is (dependent-name :cp1250) impl-enc)
+    (is (dependent-name :cp1250 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1250))))
 
@@ -389,6 +419,7 @@
                   #+allegro :cannot-treat
                   #+lispworks :cannot-treat))
     (is (dependent-name :iso-8859-13) impl-enc)
+    (is (dependent-name :iso-8859-13 :flexi-name) :iso-8859-13)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :iso-8859-13)))
   (let ((impl-enc #+sbcl :cp1257
@@ -399,6 +430,7 @@
                   #+allegro :1257
                   #+(and lispworks windows) '(win32:code-page :id 1257)))
     (is (dependent-name :cp1257) impl-enc)
+    (is (dependent-name :cp1257 :flexi-name) nil)
     (unless (eq impl-enc :cannot-treat)
       (is (independent-name impl-enc) :cp1257))))
 
@@ -412,6 +444,7 @@
                   #+allegro :unix
                   #+lispworks :lf))
     (is (dependent-name :lf) impl-eol)
+    (is (dependent-name :lf :flexi-name) :lf)
     (unless (eq impl-eol :cannot-treat)
       (is (independent-name impl-eol) :lf)))
   (let ((impl-eol #+sbcl :cannot-treat
@@ -422,6 +455,7 @@
                   #+allegro :mac
                   #+lispworks :cr))
     (is (dependent-name :cr) impl-eol)
+    (is (dependent-name :cr :flexi-name) :cr)
     (unless (eq impl-eol :cannot-treat)
       (is (independent-name impl-eol) :cr)))
   (let ((impl-eol #+sbcl :cannot-treat
@@ -432,6 +466,7 @@
                   #+allegro :doc
                   #+lispworks :crlf))
     (is (dependent-name :crlf) impl-eol)
+    (is (dependent-name :crlf :flexi-name) :crlf)
     (unless (eq impl-eol :cannot-treat)
       (is (independent-name impl-eol) :crlf))))
 


### PR DESCRIPTION
This PR mainly supports [flexi-streams](https://github.com/edicl/flexi-streams)'s external-format issued by #21.

And there is a small but important bug fix such that `inquisitor:make-external-format` generates malformed external-format because of using names for inquisitor, not for implementation.

# `inquisitor-flex` system

To avoid increasing dependencies, flexi-streams support is not loaded normally. If users need flexi-streams support, they can load `inquisitor-flex` additionally. This system provides two things:

- encoding names which flexi-streams supports
- method `inquisitor:make-external-format` for flexi-streams

## Encoding names defined in flexi-streams

When loading `inquisitor-flex`, it modifies inquisitor's `+name-mapping+` to add flexi-streams' name.

Users can get encoding name supported by flexi-streams with `dependent-name` method with optional parameter `type`: `:flexi`.

## External-format abstraction

`inquisitor:make-external-format` becomes a generic function and it needs `type` parameter. If it is specified `:impl`, it returns encoding name on CL implementation. If `inquisitor-flex` loaded, `inquisitor:make-external-format` returns flexi-streams' external-format with specifying `:type` keyword argument, like `:flexi`