### PR TITLE
Fixed CRLF line termination format on CCL.

### DIFF
--- a/src/names.lisp
+++ b/src/names.lisp
@@ -419,7 +419,7 @@
      :type :eol
      :impl-name
      #+sbcl :cannot-treat
-     #+ccl :dos
+     #+ccl :crlf
      #+clisp :dos
      #+ecl :crlf
      #+abcl :crlf


### PR DESCRIPTION
I have added this simple change because CCL does not accept the :DOS line termination format anymore. 

(it is mentioned on [the CCL documentation](https://ccl.clozure.com/manual/chapter4.5.html#Line-Termination-Table), yet it is not accepted anymore)


